### PR TITLE
PREAPPS-341 add fallback for request headers option 

### DIFF
--- a/src/request/index.ts
+++ b/src/request/index.ts
@@ -150,6 +150,7 @@ export function jsonRequest(
 	const options = {
 		...requestOptions,
 		credentials: requestOptions.credentials || 'include',
+		headers: requestOptions.headers || {},
 		origin: requestOptions.origin || DEFAULT_HOSTNAME,
 		soapPathname: requestOptions.soapPathname || DEFAULT_SOAP_PATHNAME,
 		namespace: requestOptions.namespace || Namespace.Mail


### PR DESCRIPTION
so safari 10 doesn't explode when the `headers` param is `undefined`