### PR TITLE
Adjust settings to `uglifyjs` mangler to allow CJS and UMD bundles to build correctly.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "rollup:cjs": "rollup -c rollup.config.js -m -f cjs -n $npm_package_amdName $npm_package_source -o $npm_package_main",
     "rollup:umd": "rollup -c rollup.config.js -m -f umd -n $npm_package_amdName $npm_package_source -o $npm_package_umd_main",
     "rollup:esm": "rollup -c rollup.config.js -m -f es --environment FORMAT:es -n $npm_package_amdName $npm_package_source -o $npm_package_module",
-    "minify:cjs": "uglifyjs $npm_package_main -c pure_getters,pure_funcs=classCallCheck -m toplevel -o $npm_package_main --source-map content=${npm_package_main}.map,url=zm-api-js-client.js.map,filename=${npm_package_main}.map",
-    "minify:umd": "uglifyjs $npm_package_umd_main -c pure_getters,pure_funcs=classCallCheck -m -o $npm_package_umd_main --source-map content=${npm_package_umd_main}.map,url=zm-api-js-client.umd.js.map,filename=${npm_package_umd_main}.map",
+    "minify:cjs": "uglifyjs $npm_package_main -c pure_getters,pure_funcs=classCallCheck -m toplevel,reserved=['_createClass'] --keep-fnames -o $npm_package_main --source-map content=${npm_package_main}.map,url=zm-api-js-client.js.map,filename=${npm_package_main}.map",
+    "minify:umd": "uglifyjs $npm_package_umd_main -c pure_getters,pure_funcs=classCallCheck -m toplevel,reserved=['_createClass'] --keep-fnames -o $npm_package_umd_main --source-map content=${npm_package_umd_main}.map,url=zm-api-js-client.umd.js.map,filename=${npm_package_umd_main}.map",
     "size": "echo \"Gzipped Size: $(gzip-size $npm_package_main | pretty-bytes)\"",
     "prepublishOnly": "npm test && npm run build && git commit -am $npm_package_version && git tag $npm_package_version && git push && git push --tags"
   },


### PR DESCRIPTION
Keep the `_createClass` name to avoid it being removed by dead code elimination.
Keep function names because `graphql` relies on them.