### PR TITLE
PREAPPS-548 Remove unused and shouldn't be used calendars and folders queries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@zimbra/api-client",
-  "version": "0.1.2",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/batch-client/index.ts
+++ b/src/batch-client/index.ts
@@ -8,7 +8,6 @@ import {
 	Folder,
 	FolderAction,
 	FreeBusy,
-	GetFolderResponse,
 	MessageInfo,
 	SearchResponse,
 	ShareNotification
@@ -114,15 +113,6 @@ export class ZimbraBatchClient {
 			}
 		});
 	};
-
-	public calendars = () =>
-		this.jsonRequest({
-			name: 'GetFolder',
-			body: {
-				view: FolderView.appointment,
-				tr: true
-			}
-		}).then(res => normalize(Folder)(res.folder[0].folder));
 
 	public cancelTask = ({ inviteId }: any) =>
 		this.jsonRequest({
@@ -286,7 +276,7 @@ export class ZimbraBatchClient {
 				...options,
 				tr: traverseMountpoints
 			}
-		}).then(normalize(GetFolderResponse));
+		}).then(normalize(Folder));
 	};
 
 	public getMailboxMetadata = ({ section }: GetMailboxMetadataOptions) =>

--- a/src/normalize/entities.ts
+++ b/src/normalize/entities.ts
@@ -195,10 +195,6 @@ Folder.addMapping({
 });
 export { Folder };
 
-export const GetFolderResponse = new Entity({
-	folder: ['folders', Folder]
-});
-
 const FreeBusyInstance = new Entity({
 	s: 'start',
 	e: 'end'

--- a/src/schema/generated-schema-types.ts
+++ b/src/schema/generated-schema-types.ts
@@ -21,17 +21,15 @@ export interface MailItem {
 /* Zimbra GraphQL Queries- [[SOAP API Reference]](https://files.zimbra.com/docs/soap_api/8.7.11/api-reference/index.html)- [[SOAP Documentation]](https://github.com/Zimbra/zm-mailbox/blob/develop/store/docs/soap.txt)- [[SOAP XML-to-JSON Documentation]](https://wiki.zimbra.com/wiki/Json_format_to_represent_soap) */
 export interface Query {
 	accountInfo?: AccountInfo | null;
-	calendars?: Folder[] | null;
 	folder?: Folder | null;
-	folders?: Folder[] | null;
 	freeBusy?: FreeBusy[] | null;
 	getContact?: Contact | null;
 	getContactFrequency?: ContactFrequencyResponse | null;
 	getConversation?: Conversation | null;
-	getFolder?: GetFolderResponse | null;
+	getFolder?: Folder | null;
 	getMailboxMetadata?: MailboxMetadata | null;
 	getMessage?: MessageInfo | null;
-	getSearchFolder?: GetFolderResponse | null;
+	getSearchFolder?: Folder | null;
 	getTask?: boolean | null;
 	noop?: boolean | null;
 	preferences?: Preferences | null;
@@ -448,10 +446,6 @@ export interface ContactFrequencyDataPoints {
 	value?: number | null;
 }
 
-export interface GetFolderResponse {
-	folders?: Folder[] | null;
-}
-
 export interface MailboxMetadata {
 	meta?: MailboxMetadataMeta[] | null;
 }
@@ -544,12 +538,6 @@ export interface Mutation {
 
 export interface SignatureResponse {
 	id: string;
-}
-
-export interface FolderQueryInput {
-	uuid?: string | null;
-	id?: string | null;
-	view?: FolderView | null;
 }
 
 export interface MailItemHeaderInput {
@@ -821,11 +809,14 @@ export interface ExternalAccount {
 	username: string;
 	password: string;
 }
+
+export interface FolderQueryInput {
+	uuid?: string | null;
+	id?: string | null;
+	view?: FolderView | null;
+}
 export interface FolderQueryArgs {
 	id: string;
-}
-export interface FoldersQueryArgs {
-	ids: FolderQueryInput[];
 }
 export interface FreeBusyQueryArgs {
 	names?: string[] | null;

--- a/src/schema/schema.graphql
+++ b/src/schema/schema.graphql
@@ -404,10 +404,6 @@ type Folder {
 	query: String
 }
 
-type GetFolderResponse {
-	folders: [Folder]
-}
-
 type ACL {
 	grant: [ACLGrant]
 }
@@ -951,9 +947,7 @@ input MailItemHeaderInput {
 # - [[SOAP XML-to-JSON Documentation]](https://wiki.zimbra.com/wiki/Json_format_to_represent_soap)
 type Query {
 	accountInfo: AccountInfo
-	calendars: [Folder]
 	folder(id: ID!): Folder
-	folders(ids: [FolderQueryInput]!): [Folder]
 	freeBusy(names: [String!], start: Float, end: Float): [FreeBusy]
 	getContact(id: ID!): Contact
 	getContactFrequency(
@@ -976,7 +970,7 @@ type Query {
 		depth: Int,
 		traverseMountpoints: Boolean
 		folder: GetFolderFolderInput
-	): GetFolderResponse
+	): Folder
 	getMailboxMetadata(section: String): MailboxMetadata
 	getMessage(
 		id: ID!,
@@ -990,7 +984,7 @@ type Query {
 		read: Boolean,
 		ridZ: String
 	): MessageInfo
-	getSearchFolder: GetFolderResponse
+	getSearchFolder: Folder
 	getTask(inviteId: ID!): Boolean
 	noop: Boolean
 	preferences: Preferences

--- a/src/schema/schema.ts
+++ b/src/schema/schema.ts
@@ -22,7 +22,6 @@ import {
 	CreateFolderOptions,
 	CreateSearchFolderOptions,
 	FolderOptions,
-	FoldersOptions,
 	FreeBusyOptions,
 	GetContactFrequencyOptions,
 	GetContactOptions,
@@ -51,9 +50,7 @@ export function createZimbraSchema(
 		resolvers: {
 			Query: {
 				accountInfo: client.accountInfo,
-				calendars: client.calendars,
 				folder: (_, variables) => client.folder(variables as FolderOptions),
-				folders: (_, variables) => client.folders(variables as FoldersOptions),
 				freeBusy: (_, variables) =>
 					client.freeBusy(variables as FreeBusyOptions),
 				getContact: (_, variables) =>


### PR DESCRIPTION
This should not be published until https://github.com/Zimbra/zm-x-web/pull/35 is merged, which stops using these in favor of the standard `getFolder` query