### PR TITLE
PREAPPS:634:: A dependancy related to PREAPPS-371

### DIFF
--- a/src/batch-client/types.ts
+++ b/src/batch-client/types.ts
@@ -139,7 +139,7 @@ export enum ActionType {
 
 export enum ActionResultType {
 	ConvAction = 'Conversation',
-	MsgAction = 'Message'
+	MsgAction = 'MessageInfo'
 }
 
 export interface CreateFolderOptions {


### PR DESCRIPTION
File(zm-x-web-private): src/components/mail-pane/index.js

Whenever any action is selected from context menu that is opened by right clicking on mail item, an error was getting thrown.
This was because we're trying to retrieve data to update the cache in the mutation of the respective action, and that data had "MessageInfo" as key instead of "Message". But we were using "ActionResultType" object as selector on that data.