### PR TITLE
Hotfix: Always denormalize arguments passed to `action`

### DIFF
--- a/src/batch-client/index.ts
+++ b/src/batch-client/index.ts
@@ -108,7 +108,7 @@ export class ZimbraBatchClient {
 			body: {
 				action: {
 					id: id || (ids || []).join(','),
-					...rest
+					...denormalize(ActionOptionsEntity)(rest)
 				}
 			}
 		});
@@ -158,10 +158,7 @@ export class ZimbraBatchClient {
 			});
 
 	public conversationAction = (options: ActionOptions) =>
-		this.action(
-			ActionType.conversation,
-			denormalize(ActionOptionsEntity)(options)
-		);
+		this.action(ActionType.conversation, options);
 
 	public createAppointment = (appointment: CalendarItemInput) =>
 		this.jsonRequest({
@@ -226,7 +223,7 @@ export class ZimbraBatchClient {
 		}).then(res => normalize(Folder)(res.folder[0].folder));
 
 	public folderAction = (options: ActionOptions) =>
-		this.action(ActionType.folder, denormalize(ActionOptionsEntity)(options));
+		this.action(ActionType.folder, options);
 
 	public folders = ({ ids }: FoldersOptions) =>
 		Promise.all(
@@ -352,7 +349,7 @@ export class ZimbraBatchClient {
 		);
 
 	public itemAction = (options: ActionOptions) =>
-		this.action(ActionType.item, denormalize(ActionOptionsEntity)(options));
+		this.action(ActionType.item, options);
 
 	public jsonRequest = (options: RequestOptions): Promise<RequestBody> =>
 		this.dataLoader.load(options);
@@ -378,7 +375,7 @@ export class ZimbraBatchClient {
 	};
 
 	public messageAction = (options: ActionOptions) =>
-		this.action(ActionType.message, denormalize(ActionOptionsEntity)(options));
+		this.action(ActionType.message, options);
 
 	public modifyAppointment = (appointment: CalendarItemInput) =>
 		this.jsonRequest({


### PR DESCRIPTION
This is breaking moving mail messages between folders on `master`.

There are some consumers that use the raw `action` method, so we always need to be calling `denormalize` on the arguments passed it.