### PR TITLE
PREAPPS-651:: Control width of preview pane (Preview Pane on Right)

### DIFF
--- a/src/schema/schema.graphql
+++ b/src/schema/schema.graphql
@@ -863,7 +863,6 @@ type Preferences {
 	zimbraPrefOutOfOfficeUntilDate: String
 	zimbraPrefReadingPaneEnabled: Boolean
 	zimbraPrefReadingPaneLocation: ReadingPaneLocation
-	zimbraPrefReadingPaneSashHorizontal: Int
 	zimbraPrefShowFragments: Boolean
 }
 
@@ -1258,7 +1257,6 @@ input PreferencesInput {
 	zimbraPrefOutOfOfficeUntilDate: String
 	zimbraPrefReadingPaneEnabled: Boolean
 	zimbraPrefReadingPaneLocation: ReadingPaneLocation
-	zimbraPrefReadingPaneSashHorizontal: Int
 	zimbraPrefShowFragments: Boolean
 }
 


### PR DESCRIPTION
Removed 'zimbraPrefReadingPaneSashHorizontal' from Preferences type and PreferencesInput input as that was the wrong place to put them there.