### PR TITLE
PREAPPS-1148: Autocomplete results contain repeats

### DIFF
--- a/src/apollo/zimbra-in-memory-cache.ts
+++ b/src/apollo/zimbra-in-memory-cache.ts
@@ -24,6 +24,9 @@ const dataIdFromObject = (object: any): string | null | undefined => {
 				return `${object.__typename}:${object.id}:${object.uuid}`;
 			}
 			return defaultDataIdFromObject(object);
+		case 'AutoCompleteMatch':
+			// AutoCompleteMatch is not guarenteed to have an `id`
+			return `${defaultDataIdFromObject(object)}:${object.email}`;
 		default:
 			return defaultDataIdFromObject(object);
 	}


### PR DESCRIPTION
It turns out that an `AutoCompleteMatch` is not guarenteed to have an `id`. This changes the dataId for `AutoCompleteMatch` to be unique based on the email address found in the match.