### PR TITLE
PREAPPS-934: Login error "An unknown error occurred"; Zimbra X login seems to require almost daily cache clearing

### DIFF
--- a/src/batch-client/index.ts
+++ b/src/batch-client/index.ts
@@ -518,6 +518,9 @@ export class ZimbraBatchClient {
 			name: 'Auth',
 			body: {
 				tokenType,
+				authTokenControl: {
+					voidOnExpired: true
+				},
 				account: {
 					by: 'name',
 					_content: username


### PR DESCRIPTION
Set `authTokenControl.voidOnExpired=true` to always clear AuthToken when it expires.