### PR TITLE
Return the ID of a created appointment from createAppointment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3838,12 +3838,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
@@ -3858,17 +3860,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3985,7 +3990,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3997,6 +4003,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "1.0.1"
           }
@@ -4011,6 +4018,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "1.1.11"
           }
@@ -4018,12 +4026,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "5.1.1",
             "yallist": "3.0.2"
@@ -4042,6 +4052,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4122,7 +4133,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4134,6 +4146,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1.0.2"
           }
@@ -4255,6 +4268,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",

--- a/src/batch-client/index.ts
+++ b/src/batch-client/index.ts
@@ -241,7 +241,7 @@ export class ZimbraBatchClient {
 				...denormalize(CalendarItemCreateModifyRequest)(appointment)
 			},
 			accountName: accountName
-		}).then(({ invId }) => ({ inviteId: invId }));
+		}).then(res => normalize(CalendarItemHitInfo)(res));
 
 	public createAppointmentException = (
 		accountName: string,

--- a/src/batch-client/index.ts
+++ b/src/batch-client/index.ts
@@ -241,7 +241,7 @@ export class ZimbraBatchClient {
 				...denormalize(CalendarItemCreateModifyRequest)(appointment)
 			},
 			accountName: accountName
-		});
+		}).then(({ invId }) => ({ inviteId: invId, created: !!invId }));
 
 	public createAppointmentException = (
 		accountName: string,

--- a/src/batch-client/index.ts
+++ b/src/batch-client/index.ts
@@ -241,7 +241,7 @@ export class ZimbraBatchClient {
 				...denormalize(CalendarItemCreateModifyRequest)(appointment)
 			},
 			accountName: accountName
-		}).then(({ invId }) => ({ inviteId: invId, created: !!invId }));
+		}).then(({ invId }) => ({ inviteId: invId }));
 
 	public createAppointmentException = (
 		accountName: string,

--- a/src/schema/generated-schema-types.ts
+++ b/src/schema/generated-schema-types.ts
@@ -991,7 +991,7 @@ export interface Mutation {
 	checkCalendar?: boolean | null;
 	contactAction?: ActionOpResponse | null;
 	conversationAction?: boolean | null;
-	createAppointment?: boolean | null;
+	createAppointment?: createAppointmentResponse | null;
 	createAppointmentException?: boolean | null;
 	createCalendar?: boolean | null;
 	createContact?: Contact | null;
@@ -1055,6 +1055,11 @@ export interface ActionOpResponse {
 export interface ActionOpResponseData {
 	id: string;
 	op: string;
+}
+
+export interface createAppointmentResponse {
+	created?: boolean | null;
+	inviteId?: string | null;
 }
 
 export interface SignatureResponse {

--- a/src/schema/generated-schema-types.ts
+++ b/src/schema/generated-schema-types.ts
@@ -991,7 +991,7 @@ export interface Mutation {
 	checkCalendar?: boolean | null;
 	contactAction?: ActionOpResponse | null;
 	conversationAction?: boolean | null;
-	createAppointment?: createAppointmentResponse | null;
+	createAppointment?: CalendarItemHitInfo | null;
 	createAppointmentException?: boolean | null;
 	createCalendar?: boolean | null;
 	createContact?: Contact | null;
@@ -1055,11 +1055,6 @@ export interface ActionOpResponse {
 export interface ActionOpResponseData {
 	id: string;
 	op: string;
-}
-
-export interface createAppointmentResponse {
-	created?: boolean | null;
-	inviteId?: string | null;
 }
 
 export interface SignatureResponse {

--- a/src/schema/schema.graphql
+++ b/src/schema/schema.graphql
@@ -2010,11 +2010,6 @@ type SMimeMessage {
 	content: String
 }
 
-type createAppointmentResponse {
-	created: Boolean
-	inviteId: String
-}
-
 ##### End Of SMIME Certificates type #####
 
 type ActionOpResponseData {
@@ -2164,7 +2159,7 @@ type Mutation {
 		ids: [ID!]!
 		op: String!
 	): Boolean
-	createAppointment(accountName: String, appointment: CalendarItemInput!): createAppointmentResponse
+	createAppointment(accountName: String, appointment: CalendarItemInput!): CalendarItemHitInfo
 	createAppointmentException(accountName: String, appointment: CalendarItemInput!): Boolean
 	createCalendar(name: String!, color: Int!, url: String): Boolean
 	createContact(contact: CreateContactInput!): Contact

--- a/src/schema/schema.graphql
+++ b/src/schema/schema.graphql
@@ -2010,6 +2010,11 @@ type SMimeMessage {
 	content: String
 }
 
+type createAppointmentResponse {
+	created: Boolean
+	inviteId: String
+}
+
 ##### End Of SMIME Certificates type #####
 
 type ActionOpResponseData {
@@ -2159,7 +2164,7 @@ type Mutation {
 		ids: [ID!]!
 		op: String!
 	): Boolean
-	createAppointment(accountName: String, appointment: CalendarItemInput!): Boolean
+	createAppointment(accountName: String, appointment: CalendarItemInput!): createAppointmentResponse
 	createAppointmentException(accountName: String, appointment: CalendarItemInput!): Boolean
 	createCalendar(name: String!, color: Int!, url: String): Boolean
 	createContact(contact: CreateContactInput!): Contact


### PR DESCRIPTION
Companion PR of [zm-x-web's #449](https://github.com/ZimbraOS/zm-x-web/pull/449).

This is needed because for Jitsi/OnlyOffice integrations, we require the `inviteId` generated upon creation of an appointment, in order to update that appointment on the spot.