### PR TITLE
PREAPPS-1160 Use indexdb for storing graphql cache

### DIFF
--- a/src/apollo/sync-offline-operations/index.ts
+++ b/src/apollo/sync-offline-operations/index.ts
@@ -50,7 +50,7 @@ export class SyncOfflineOperations {
 
 	init = () =>
 		this.getOfflineData().then(
-			stored => (this.offlineData = JSON.parse(stored) || [])
+			stored => (this.offlineData = (stored && JSON.parse(stored)) || [])
 		);
 
 	sync = () => {


### PR DESCRIPTION
- Fixed error where empty graphql cache was throwing javascript error