### PR TITLE
PREAPPS-1990 Calendar | Cannot save "Default Calendar" setting due to GraphQL error

### DIFF
--- a/src/schema/schema.graphql
+++ b/src/schema/schema.graphql
@@ -1073,7 +1073,7 @@ type Preferences {
 	zimbraPrefCalendarInitialView: PrefCalendarInitialView
 	zimbraPrefCalendarReminderEmail: String
 	zimbraPrefCalendarWorkingHours: String
-	zimbraPrefDefaultCalendarId: Int
+	zimbraPrefDefaultCalendarId: ID
 	zimbraPrefDeleteInviteOnReply: Boolean
 	zimbraPrefDisplayExternalImages: Boolean
 	zimbraPrefGroupMailBy: String
@@ -1697,7 +1697,7 @@ input InviteReplyInput {
 input PreferencesInput {
 	zimbraPrefAutoAddAppointmentsToCalendar: Boolean
 	zimbraPrefCalendarAutoAddInvites: Boolean
-	zimbraPrefDefaultCalendarId: Int
+	zimbraPrefDefaultCalendarId: ID
 	zimbraPrefCalendarFirstDayOfWeek: Int
 	zimbraPrefCalendarInitialView: PrefCalendarInitialView
 	zimbraPrefCalendarReminderEmail: String


### PR DESCRIPTION
- change type of zimbraPrefDefaultCalendarId to ID instead of Int