### PR TITLE
PREAPPS-2296: Account Recovery shows misleading error when password reset is disabled

### DIFF
--- a/src/schema/generated-schema-types.ts
+++ b/src/schema/generated-schema-types.ts
@@ -1270,6 +1270,12 @@ export interface ModifyIdentityInput {
 	attrs?: IdentityAttrsInput | null;
 }
 
+export enum ResetPasswordStatus {
+	Enabled = 'enabled',
+	Disabled = 'disabled',
+	Suspended = 'suspended'
+}
+
 export enum PrefCalendarInitialView {
 	Day = 'day',
 	List = 'list',

--- a/src/schema/schema.graphql
+++ b/src/schema/schema.graphql
@@ -1109,6 +1109,7 @@ type AccountInfoAttrs {
 	zimbraFeatureManageZimlets: Boolean
 	zimbraFeatureTwoFactorAuthAvailable: Boolean
 	zimbraTwoFactorAuthEnabled: Boolean
+	zimbraFeatureResetPasswordStatus: String
 }
 
 type Identities {

--- a/src/schema/schema.graphql
+++ b/src/schema/schema.graphql
@@ -271,6 +271,12 @@ enum ZimletPresence {
 	disabled
 }
 
+enum ResetPasswordStatus {
+	enabled
+	disabled
+	suspended
+}
+
 type AuthResponse {
 	authToken: [AuthToken]
 	twoFactorAuthRequired: TwoFactorAuthRequired
@@ -1096,7 +1102,7 @@ type AccountInfoAttrs {
 	zimbraFeatureCalendarEnabled: Boolean
 	zimbraFeatureRelatedContactsEnabled: Boolean
 	zimbraFeatureChangePasswordEnabled: Boolean
-	zimbraFeatureResetPasswordEnabled: Boolean
+	zimbraFeatureResetPasswordStatus: ResetPasswordStatus
 	zimbraFeatureWebClientOfflineAccessEnabled: Boolean
 	zimbraMailBlacklistMaxNumEntries: Int
 	zimbraPublicSharingEnabled: Boolean
@@ -1109,7 +1115,6 @@ type AccountInfoAttrs {
 	zimbraFeatureManageZimlets: Boolean
 	zimbraFeatureTwoFactorAuthAvailable: Boolean
 	zimbraTwoFactorAuthEnabled: Boolean
-	zimbraFeatureResetPasswordStatus: String
 }
 
 type Identities {


### PR DESCRIPTION
Add `zimbraFeatureResetPasswordStatus` to AccountInfoAttrs.