### PR TITLE
PREAPPS-2736: Do not save mail to sent folder

### DIFF
--- a/src/schema/generated-schema-types.ts
+++ b/src/schema/generated-schema-types.ts
@@ -741,8 +741,6 @@ export interface IdentityAttrsInput {
 
 	zimbraPrefReplyToEnabled?: boolean | null;
 
-	zimbraPrefSaveToSent?: boolean | null;
-
 	zimbraPrefSentMailFolder?: string | null;
 }
 
@@ -798,6 +796,8 @@ export interface PreferencesInput {
 	zimbraPrefReadingPaneEnabled?: boolean | null;
 
 	zimbraPrefReadingPaneLocation?: ReadingPaneLocation | null;
+
+	zimbraPrefSaveToSent?: boolean | null;
 
 	zimbraPrefShowFragments?: boolean | null;
 

--- a/src/schema/schema.graphql
+++ b/src/schema/schema.graphql
@@ -1200,7 +1200,6 @@ type IdentityAttrs {
 	zimbraPrefReplyToAddress: String
 	zimbraPrefReplyToDisplay: String
 	zimbraPrefReplyToEnabled: Boolean
-	zimbraPrefSaveToSent: Boolean
 	zimbraPrefSentMailFolder: String
 }
 
@@ -1234,6 +1233,7 @@ type Preferences {
 	zimbraPrefReadingPaneLocation: ReadingPaneLocation
 	zimbraPrefPasswordRecoveryAddress: String
 	zimbraPrefPasswordRecoveryAddressStatus: PasswordRecoveryAddressStatus
+	zimbraPrefSaveToSent: Boolean
 	zimbraPrefShowFragments: Boolean
 	zimbraPrefWebClientOfflineBrowserKey: String
 	zimbraPrefTimeZoneId: String
@@ -1995,6 +1995,7 @@ input PreferencesInput {
 	zimbraPrefOutOfOfficeUntilDate: String
 	zimbraPrefReadingPaneEnabled: Boolean
 	zimbraPrefReadingPaneLocation: ReadingPaneLocation
+	zimbraPrefSaveToSent: Boolean
 	zimbraPrefShowFragments: Boolean
 	zimbraPrefWebClientOfflineBrowserKey: String
 	zimbraPrefTimeZoneId: String
@@ -2234,7 +2235,6 @@ input IdentityAttrsInput {
 	zimbraPrefReplyToAddress: String
 	zimbraPrefReplyToDisplay: String
 	zimbraPrefReplyToEnabled: Boolean
-	zimbraPrefSaveToSent: Boolean
 	zimbraPrefSentMailFolder: String
 }
 


### PR DESCRIPTION
Move `zimbraPrefSaveToSent` from `attrs` to `prefs`.

It seems like this was put in the wrong location a long time ago.