### PR TITLE
PREAPPS-1860: Show notifications when new messages arrive

### DIFF
--- a/src/schema/schema.graphql
+++ b/src/schema/schema.graphql
@@ -1258,6 +1258,8 @@ type Preferences {
 	zimbraPrefCalendarApptReminderWarningTime: Int
 	zimbraPrefCalendarShowPastDueReminders: Boolean
 	zimbraPrefCalendarToasterEnabled: Boolean
+	zimbraPrefMailToasterEnabled: Boolean
+	zimbraPrefShowAllNewMailNotifications: Boolean
 	zimbraPrefDefaultCalendarId: ID
 	zimbraPrefDeleteInviteOnReply: Boolean
 	zimbraPrefDelegatedSendSaveTarget: PrefDelegatedSendSaveTarget
@@ -2060,6 +2062,8 @@ input PreferencesInput {
 	zimbraPrefCalendarApptReminderWarningTime: Int
 	zimbraPrefCalendarShowPastDueReminders: Boolean
 	zimbraPrefCalendarToasterEnabled: Boolean
+	zimbraPrefMailToasterEnabled: Boolean
+	zimbraPrefShowAllNewMailNotifications: Boolean
 	zimbraPrefDelegatedSendSaveTarget: PrefDelegatedSendSaveTarget
 	zimbraPrefDisplayExternalImages: Boolean
 	zimbraPrefGroupMailBy: String


### PR DESCRIPTION
New mail(only with flag 'unread') received in notifications object is written to local cache using `@client` directive. Client query listening to the same is updated with new mail. 