### PR TITLE
PREAPPS-4602: GraphQL error 'upload not found' shows after attaching .ics file; draft mail in Drafts does not contain .ics file

### DIFF
--- a/src/utils/normalize-mime-parts.ts
+++ b/src/utils/normalize-mime-parts.ts
@@ -152,7 +152,6 @@ export function normalizeMimeParts(
 				part.contentType !== 'application/pkcs7-mime' &&
 					part.contentType !== 'application/pkcs7-signature' &&
 					part.contentType !== 'application/x-pkcs7-signature' &&
-					!(part.filename && part.filename.endsWith('.ics')) &&
 					(acc[mode] || (acc[mode] = [])).push(processAttachment(part));
 
 				message.attributes = message.attributes || {};


### PR DESCRIPTION
Remove special case for ICS attachments.