### PR TITLE
PREAPPS-5175 Removed zimbraPasswordModifiedTime from graphql schema

### DIFF
--- a/src/schema/generated-schema-types.ts
+++ b/src/schema/generated-schema-types.ts
@@ -78,7 +78,6 @@ export type AccountInfoAttrs = {
   zimbraPasswordMinAge?: Maybe<Scalars['Int']>;
   zimbraPasswordMaxAge?: Maybe<Scalars['Int']>;
   zimbraPasswordEnforceHistory?: Maybe<Scalars['Int']>;
-  zimbraPasswordModifiedTime?: Maybe<Scalars['Int']>;
   zimbraPasswordAllowedChars?: Maybe<Scalars['String']>;
   zimbraPasswordAllowedPunctuationChars?: Maybe<Scalars['String']>;
   zimbraFeatureChangePasswordEnabled?: Maybe<Scalars['Boolean']>;

--- a/src/schema/schema.graphql
+++ b/src/schema/schema.graphql
@@ -1237,7 +1237,6 @@ type AccountInfoAttrs {
 	zimbraPasswordMinAge: Int
 	zimbraPasswordMaxAge: Int
 	zimbraPasswordEnforceHistory: Int
-	zimbraPasswordModifiedTime: Int
 	zimbraPasswordAllowedChars: String
 	zimbraPasswordAllowedPunctuationChars: String
 	zimbraFeatureChangePasswordEnabled: Boolean


### PR DESCRIPTION
- this attribute is not being in use in the app
- also this attribute was mapped to integer but server uses gentime data format for this and both are not compatible as server was returning 20200721163834.298Z as value