### PR TITLE
PREAPPS-4517:- TypeError when opening Synacor Global Address List

### DIFF
--- a/src/utils/normalize-otherAttribute-contact.ts
+++ b/src/utils/normalize-otherAttribute-contact.ts
@@ -117,6 +117,15 @@ export function normalizeOtherAttr(data: any) {
 				: castValueOfNickname;
 		}
 
+		let castValueOfUserCert: any = contact._attrs['userCertificate'];
+
+		if (castValueOfUserCert) {
+			// To Do:- Handle multiple UserCertificates for a contact
+			contact._attrs['userCertificate'] = Array.isArray(castValueOfUserCert)
+				? castValueOfUserCert[0]
+				: castValueOfUserCert;
+		}
+
 		Object.keys(contact._attrs)
 			.filter(key => !supportedContactAttributes.includes(key))
 			.forEach(


### PR DESCRIPTION

the reason we need to cast userCertificate value to string:-

1) User Certificate comes as **string** when their is only one certificate available :-
![image](https://user-images.githubusercontent.com/44395134/89282202-ce0b2080-d668-11ea-8c19-3807b8e1ac4f.png)

2) User certificate comes as **Array** when their are multiple certificates:-
![image](https://user-images.githubusercontent.com/44395134/89282620-6dc8ae80-d669-11ea-84d8-8813e35db3dc.png)

