### PR TITLE
PREAPPS-5503: adding the unreadDescendent to check if any subfolder or the folder itself has a unread mails in the hireracy

### DIFF
--- a/src/batch-client/constants.ts
+++ b/src/batch-client/constants.ts
@@ -1,2 +1,17 @@
 // Zimbra Prefs which needs to be casted, from string type to array type & vice versa
 export const CASTING_PREFS = ['zimbraPrefMailTrustedSenderList'];
+
+export const USER_FOLDER_IDS = {
+	ROOT: 1,
+	INBOX: 2,
+	TRASH: 3,
+	JUNK: 4,
+	SENT: 5,
+	DRAFTS: 6,
+	CONTACTS: 7,
+	CALENDAR: 10,
+	EMAILED_CONTACTS: 13,
+	CHAT: 14,
+	TASKS: 15,
+	BRIEFCASE: 16
+};

--- a/src/batch-client/types.ts
+++ b/src/batch-client/types.ts
@@ -329,10 +329,10 @@ export interface RecoverAccountOptions {
 }
 
 export interface ResetPasswordOptions {
-	dryRun: boolean;
-	password: string;
-	getPasswordRules: boolean;
 	cancelResetPassword: boolean;
+	dryRun: boolean;
+	getPasswordRules: boolean;
+	password: string;
 }
 
 export interface ExternalAccountModifyInput {

--- a/src/schema/generated-schema-types.ts
+++ b/src/schema/generated-schema-types.ts
@@ -1206,6 +1206,7 @@ export type Folder = {
   userId?: Maybe<Scalars['ID']>;
   broken?: Maybe<Scalars['Boolean']>;
   deletable?: Maybe<Scalars['Boolean']>;
+  unreadDescendent?: Maybe<Scalars['Boolean']>;
 };
 
 export type Acl = {

--- a/src/schema/schema.graphql
+++ b/src/schema/schema.graphql
@@ -1122,6 +1122,7 @@ type Folder {
 	userId: ID
 	broken: Boolean #shared folder link is broken or not
 	deletable: Boolean
+	unreadDescendent: Boolean
 }
 
 type ACL {


### PR DESCRIPTION
Function setUnreadDescendentFlag will check only if the folder View is null or Message , null because the follders that are through imap or pop
hasUnreadDescendent will set the flag unreadDescendent if a folders subfolder or itself has a unread count