### PR TITLE
ZBUG-1720: added phoneticFirst/LastName to graphql schema

### DIFF
--- a/src/schema/generated-schema-types.ts
+++ b/src/schema/generated-schema-types.ts
@@ -830,8 +830,10 @@ export type Contact = {
 export type ContactAttributes = {
   __typename?: 'ContactAttributes';
   firstName?: Maybe<Scalars['String']>;
+  phoneticFirstName?: Maybe<Scalars['String']>;
   middleName?: Maybe<Scalars['String']>;
   lastName?: Maybe<Scalars['String']>;
+  phoneticLastName?: Maybe<Scalars['String']>;
   fullName?: Maybe<Scalars['String']>;
   maidenName?: Maybe<Scalars['String']>;
   namePrefix?: Maybe<Scalars['String']>;
@@ -907,8 +909,10 @@ export type ContactAttributes = {
 
 export type ContactAttrsInput = {
   firstName?: Maybe<Scalars['String']>;
+  phoneticFirstName?: Maybe<Scalars['String']>;
   middleName?: Maybe<Scalars['String']>;
   lastName?: Maybe<Scalars['String']>;
+  phoneticLastName?: Maybe<Scalars['String']>;
   fullName?: Maybe<Scalars['String']>;
   maidenName?: Maybe<Scalars['String']>;
   namePrefix?: Maybe<Scalars['String']>;

--- a/src/schema/schema.graphql
+++ b/src/schema/schema.graphql
@@ -1638,8 +1638,10 @@ type OtherContactAttribute {
 
 type ContactAttributes {
 	firstName: String
+	phoneticFirstName: String
 	middleName: String
 	lastName: String
+	phoneticLastName: String
 	fullName: String
 	maidenName: String
 	namePrefix: String
@@ -1742,8 +1744,10 @@ input OtherContactAttributeInput {
 
 input ContactAttrsInput {
 	firstName: String
+	phoneticFirstName: String
 	middleName: String
 	lastName: String
+	phoneticLastName: String
 	fullName: String
 	maidenName: String
 	namePrefix: String

--- a/src/utils/normalize-otherAttribute-contact.ts
+++ b/src/utils/normalize-otherAttribute-contact.ts
@@ -6,8 +6,10 @@ import { ContactInputRequest } from '../normalize/entities';
 
 const supportedContactAttributes = [
 	'firstName',
+	'phoneticFirstName',
 	'middleName',
 	'lastName',
+	'phoneticLastName',
 	'fullName',
 	'maidenName',
 	'namePrefix',


### PR DESCRIPTION
**Change:**
* added `phoneticLastName` and `phoneticFirstName` of a contact to graphql schema. Then they are stored in `attributes` rather than `attributes.other` of a contact data.

**Related PR:**
* https://github.com/ZimbraOS/zm-x-web/pull/3470