### PR TITLE
PREAPPS-6191 : Sign/Sign+Encrypt emails using Server SMIME.

### DIFF
--- a/src/batch-client/index.ts
+++ b/src/batch-client/index.ts
@@ -157,10 +157,8 @@ function normalizeMessage(
 	message: { [key: string]: any },
 	{ origin, jwtToken, isDesktop }: { isDesktop?: string; jwtToken?: string; origin?: string }
 ) {
-	const normalizedMessage = normalize(MessageInfo)(message);
-	normalizedMessage.attributes =
-		normalizedMessage.attributes &&
-		mapValuesDeep(normalizedMessage.attributes, coerceStringToBoolean);
+	let normalizedMessage = normalize(MessageInfo)(message);
+	normalizedMessage = normalizedMessage && mapValuesDeep(normalizedMessage, coerceStringToBoolean);
 
 	return normalizeEmailAddresses(
 		normalizeMimeParts(normalizedMessage, { origin, jwtToken, isDesktop })

--- a/src/batch-client/index.ts
+++ b/src/batch-client/index.ts
@@ -44,6 +44,7 @@ import {
 	SearchResponse,
 	SendMessageInfo,
 	ShareNotification,
+	SmimeCertInfoResponse,
 	Tag,
 	ZimletConfigEntity
 } from '../normalize/entities';
@@ -82,6 +83,7 @@ import {
 	ModifyIdentityInput,
 	PreferencesInput,
 	RevokeRightsInput,
+	SaveSMimeCertInputUpload,
 	SearchFolderInput,
 	SendMessageInput,
 	ShareNotificationInput,
@@ -1233,6 +1235,12 @@ export class ZimbraBatchClient {
 			namespace: Namespace.Account
 		}).then(res => mapValuesDeep(res, coerceStringToBoolean));
 
+	public getSMimeCertInfo = () =>
+		this.jsonRequest({
+			name: 'GetSmimeCertificateInfo',
+			namespace: Namespace.Account
+		}).then(certificate => normalize(SmimeCertInfoResponse)(certificate || {}));
+
 	public getSMimePublicCerts = (options: GetSMimePublicCertsOptions) =>
 		this.jsonRequest({
 			name: 'GetSMIMEPublicCerts',
@@ -1644,6 +1652,16 @@ export class ZimbraBatchClient {
 		}).then(({ m: messages }) => ({
 			message: messages && messages.map(this.normalizeMessage)
 		}));
+
+	public saveSMimeCert = (upload: SaveSMimeCertInputUpload, password: string) =>
+		this.jsonRequest({
+			name: 'SaveSmimeCertificate',
+			body: {
+				upload,
+				password
+			},
+			namespace: Namespace.Account
+		}).then(certificate => normalize(SmimeCertInfoResponse)(certificate || {}));
 
 	public search = (options: SearchOptions) =>
 		this.jsonRequest({

--- a/src/batch-client/index.ts
+++ b/src/batch-client/index.ts
@@ -1694,10 +1694,19 @@ export class ZimbraBatchClient {
 			singleRequest: true
 		}).then(res => normalize(CalendarItemHitInfo)(res));
 
-	public sendMessage = (message: SendMessageInput, accountName: string) =>
+	public sendMessage = (
+		message: SendMessageInput,
+		accountName: string,
+		sign: Boolean,
+		encrypt: Boolean
+	) =>
 		this.jsonRequest({
-			name: 'SendMsg',
-			body: denormalize(SendMessageInfo)({ message }),
+			name: !(sign || encrypt) ? 'SendMsg' : 'SendSecureMsg',
+			body: {
+				...denormalize(SendMessageInfo)({ message }),
+				...(sign && { sign: true }),
+				...(encrypt && { encrypt: true })
+			},
 			singleRequest: true,
 			accountName: accountName
 		}).then(normalize(SendMessageInfo));

--- a/src/normalize/entities.ts
+++ b/src/normalize/entities.ts
@@ -484,7 +484,8 @@ const contactFields = {
 	sf: 'sortField',
 	t: 'tags',
 	tn: 'tagNames',
-	_attrs: ['attributes', ContactAttributes]
+	_attrs: ['attributes', ContactAttributes],
+	certificate: ['certificate', SmimeCert]
 };
 
 const contactListMembers = new Entity({

--- a/src/normalize/entities.ts
+++ b/src/normalize/entities.ts
@@ -528,6 +528,44 @@ export const GetAppointmentResponse = new Entity({
 	appt: ['appointment', AppointmentInfo]
 });
 
+const SmimeCertsSubjectRfc822Name = new Entity({
+	_content: 'content'
+});
+
+const SmimeCertsSubjectAltName = new Entity({
+	rfc822Name: ['rfc822Name', SmimeCertsSubjectRfc822Name]
+});
+
+const SmimeCertsIssuedBy = new Entity({
+	c: 'country',
+	cn: 'commonName',
+	emailAddress: 'emailAddress',
+	l: 'locality',
+	o: 'organizationName',
+	st: 'state'
+});
+
+const SmimeCertsIssuedTo = new Entity({
+	c: 'country',
+	cn: 'commonName',
+	emailAddress: 'emailAddress',
+	o: 'organizationName',
+	ou: 'organizationUnit',
+	st: 'state'
+});
+
+const SmimeCerts = new Entity({
+	issuedBy: ['issuedBy', SmimeCertsIssuedBy],
+	issuedTo: ['issuedTo', SmimeCertsIssuedTo],
+	pubCertId: 'publicCertificateId',
+	pvtKeyId: 'privateKeyId',
+	subjectAltName: ['subjectAltName', SmimeCertsSubjectAltName]
+});
+
+export const SmimeCertInfoResponse = new Entity({
+	certificate: ['certificates', SmimeCerts]
+});
+
 const RedirectAction = new Entity({
 	a: 'address'
 });

--- a/src/normalize/entities.ts
+++ b/src/normalize/entities.ts
@@ -201,6 +201,43 @@ MimePart.addMapping({
 	attach: ['attachments', AttachmentsInfo]
 });
 
+const SmimeCertsSubjectRfc822Name = new Entity({
+	_content: 'content'
+});
+
+const SmimeCertsSubjectAltName = new Entity({
+	rfc822Name: ['rfc822Name', SmimeCertsSubjectRfc822Name]
+});
+
+const commonSmimeCertsFields = {
+	c: 'country',
+	cn: 'commonName',
+	o: 'organizationName',
+	st: 'state'
+};
+
+const SmimeCertsIssuedBy = new Entity({
+	...commonSmimeCertsFields,
+	l: 'locality'
+});
+
+const SmimeCertsIssuedTo = new Entity({
+	...commonSmimeCertsFields,
+	ou: 'organizationUnit'
+});
+
+const SmimeCert = new Entity({
+	issuedBy: ['issuedBy', SmimeCertsIssuedBy],
+	issuedTo: ['issuedTo', SmimeCertsIssuedTo],
+	pubCertId: 'publicCertificateId',
+	pvtKeyId: 'privateKeyId',
+	subjectAltName: ['subjectAltName', SmimeCertsSubjectAltName]
+});
+
+export const SmimeCertInfoResponse = new Entity({
+	certificate: ['certificates', SmimeCert]
+});
+
 const commonMailItemFields = {
 	...commonMessageFields,
 	e: ['emailAddresses', MailItemEmailAddress],
@@ -210,7 +247,8 @@ const commonMailItemFields = {
 	su: 'subject',
 	origid: 'origId',
 	attach: ['attachments', AttachmentsInfo],
-	rt: 'replyType'
+	rt: 'replyType',
+	certificate: ['certificate', SmimeCert]
 };
 
 const SendMessageFields = new Entity({
@@ -526,44 +564,6 @@ export const SearchCalendarResourcesResponse = new Entity({
 
 export const GetAppointmentResponse = new Entity({
 	appt: ['appointment', AppointmentInfo]
-});
-
-const SmimeCertsSubjectRfc822Name = new Entity({
-	_content: 'content'
-});
-
-const SmimeCertsSubjectAltName = new Entity({
-	rfc822Name: ['rfc822Name', SmimeCertsSubjectRfc822Name]
-});
-
-const SmimeCertsIssuedBy = new Entity({
-	c: 'country',
-	cn: 'commonName',
-	emailAddress: 'emailAddress',
-	l: 'locality',
-	o: 'organizationName',
-	st: 'state'
-});
-
-const SmimeCertsIssuedTo = new Entity({
-	c: 'country',
-	cn: 'commonName',
-	emailAddress: 'emailAddress',
-	o: 'organizationName',
-	ou: 'organizationUnit',
-	st: 'state'
-});
-
-const SmimeCerts = new Entity({
-	issuedBy: ['issuedBy', SmimeCertsIssuedBy],
-	issuedTo: ['issuedTo', SmimeCertsIssuedTo],
-	pubCertId: 'publicCertificateId',
-	pvtKeyId: 'privateKeyId',
-	subjectAltName: ['subjectAltName', SmimeCertsSubjectAltName]
-});
-
-export const SmimeCertInfoResponse = new Entity({
-	certificate: ['certificates', SmimeCerts]
 });
 
 const RedirectAction = new Entity({

--- a/src/request/types.ts
+++ b/src/request/types.ts
@@ -19,12 +19,14 @@ export interface BaseRequestOptions {
 	authToken?: string;
 	credentials?: RequestCredentials;
 	csrfToken?: string | null;
+	encrypt?: Boolean;
 	fetchOptions?: any;
 	headers?: any;
 	jwtToken?: string | null;
 	origin?: string;
 	sessionId?: SessionId;
 	sessionSeq?: SessionSeq;
+	sign?: Boolean;
 	singleRequest?: boolean;
 	soapPathname?: string;
 	userAgent?: UserAgent;

--- a/src/schema/generated-schema-types.ts
+++ b/src/schema/generated-schema-types.ts
@@ -2222,9 +2222,11 @@ export type MessageInfo = MailItem & {
   autoSendTime?: Maybe<Scalars['Float']>;
   bcc?: Maybe<Array<Maybe<EmailAddress>>>;
   cc?: Maybe<Array<Maybe<EmailAddress>>>;
+  certificate?: Maybe<Array<Maybe<SmimeCert>>>;
   changeDate?: Maybe<Scalars['Float']>;
   conversationId?: Maybe<Scalars['ID']>;
   date?: Maybe<Scalars['Float']>;
+  decryptionErrorCode?: Maybe<Scalars['String']>;
   emailAddresses?: Maybe<Array<Maybe<EmailAddress>>>;
   excerpt?: Maybe<Scalars['String']>;
   flags?: Maybe<Scalars['String']>;
@@ -2234,6 +2236,8 @@ export type MessageInfo = MailItem & {
   id?: Maybe<Scalars['ID']>;
   inlineAttachments?: Maybe<Array<Maybe<MimePart>>>;
   invitations?: Maybe<Array<Maybe<InviteInfo>>>;
+  isEncrypted?: Maybe<Scalars['Boolean']>;
+  isSigned?: Maybe<Scalars['Boolean']>;
   local?: Maybe<Scalars['Boolean']>;
   mimeParts?: Maybe<Array<Maybe<MimePart>>>;
   modifiedSequence?: Maybe<Scalars['Float']>;
@@ -4003,26 +4007,27 @@ export type Skin = {
   _content?: Maybe<Scalars['String']>;
 };
 
-export type SmimeCertInfoResponse = {
-  __typename?: 'SmimeCertInfoResponse';
-  certificates?: Maybe<Array<Maybe<SmimeCerts>>>;
-};
-
-export type SmimeCerts = {
-  __typename?: 'SmimeCerts';
+export type SmimeCert = {
+  __typename?: 'SmimeCert';
   default?: Maybe<Scalars['Boolean']>;
   emailAddress?: Maybe<Scalars['String']>;
-  issuedBy?: Maybe<SmimeCertsIssuedBy>;
-  issuedTo?: Maybe<SmimeCertsIssuedTo>;
+  errorCode?: Maybe<Scalars['String']>;
+  issuedBy?: Maybe<SmimeCertIssuedBy>;
+  issuedTo?: Maybe<SmimeCertIssuedTo>;
   privateKeyId?: Maybe<Scalars['String']>;
   publicCertificateId?: Maybe<Scalars['String']>;
-  signature?: Maybe<SmimeCertsSignature>;
-  subjectAltName?: Maybe<SmimeCertsSubjectAltName>;
-  validity?: Maybe<SmimeCertsValidity>;
+  signature?: Maybe<SmimeCertSignature>;
+  subjectAltName?: Maybe<SmimeCertSubjectAltName>;
+  validity?: Maybe<SmimeCertValidity>;
 };
 
-export type SmimeCertsIssuedBy = {
-  __typename?: 'SmimeCertsIssuedBy';
+export type SmimeCertInfoResponse = {
+  __typename?: 'SmimeCertInfoResponse';
+  certificates?: Maybe<Array<Maybe<SmimeCert>>>;
+};
+
+export type SmimeCertIssuedBy = {
+  __typename?: 'SmimeCertIssuedBy';
   commonName?: Maybe<Scalars['String']>;
   country?: Maybe<Scalars['String']>;
   emailAddress?: Maybe<Scalars['String']>;
@@ -4031,8 +4036,8 @@ export type SmimeCertsIssuedBy = {
   state?: Maybe<Scalars['String']>;
 };
 
-export type SmimeCertsIssuedTo = {
-  __typename?: 'SmimeCertsIssuedTo';
+export type SmimeCertIssuedTo = {
+  __typename?: 'SmimeCertIssuedTo';
   commonName?: Maybe<Scalars['String']>;
   country?: Maybe<Scalars['String']>;
   emailAddress?: Maybe<Scalars['String']>;
@@ -4041,24 +4046,24 @@ export type SmimeCertsIssuedTo = {
   state?: Maybe<Scalars['String']>;
 };
 
-export type SmimeCertsSignature = {
-  __typename?: 'SmimeCertsSignature';
+export type SmimeCertSignature = {
+  __typename?: 'SmimeCertSignature';
   algorithm?: Maybe<Scalars['String']>;
   serialNo?: Maybe<Scalars['String']>;
 };
 
-export type SmimeCertsSubjectAltName = {
-  __typename?: 'SmimeCertsSubjectAltName';
-  rfc822Name?: Maybe<Array<Maybe<SmimeCertsSubjectRfc822Name>>>;
+export type SmimeCertSubjectAltName = {
+  __typename?: 'SmimeCertSubjectAltName';
+  rfc822Name?: Maybe<Array<Maybe<SmimeCertSubjectRfc822Name>>>;
 };
 
-export type SmimeCertsSubjectRfc822Name = {
-  __typename?: 'SmimeCertsSubjectRfc822Name';
+export type SmimeCertSubjectRfc822Name = {
+  __typename?: 'SmimeCertSubjectRfc822Name';
   content?: Maybe<Scalars['String']>;
 };
 
-export type SmimeCertsValidity = {
-  __typename?: 'SmimeCertsValidity';
+export type SmimeCertValidity = {
+  __typename?: 'SmimeCertValidity';
   endDate?: Maybe<Scalars['Float']>;
   startDate?: Maybe<Scalars['Float']>;
 };

--- a/src/schema/generated-schema-types.ts
+++ b/src/schema/generated-schema-types.ts
@@ -817,6 +817,7 @@ export enum ConnectionType {
 export type Contact = {
   __typename?: 'Contact';
   attributes?: Maybe<ContactAttributes>;
+  certificate?: Maybe<Array<Maybe<SmimeCert>>>;
   date?: Maybe<Scalars['Float']>;
   fileAsStr?: Maybe<Scalars['String']>;
   folderId?: Maybe<Scalars['ID']>;

--- a/src/schema/generated-schema-types.ts
+++ b/src/schema/generated-schema-types.ts
@@ -2921,7 +2921,9 @@ export type MutationSendInviteReplyArgs = {
 
 export type MutationSendMessageArgs = {
   accountName?: Maybe<Scalars['String']>;
+  encrypt?: Maybe<Scalars['Boolean']>;
   message: SendMessageInput;
+  sign?: Maybe<Scalars['Boolean']>;
 };
 
 

--- a/src/schema/generated-schema-types.ts
+++ b/src/schema/generated-schema-types.ts
@@ -2449,6 +2449,7 @@ export type Mutation = {
   revokeTrustedDevice?: Maybe<Scalars['Boolean']>;
   saveDocument?: Maybe<SaveDocumentResponse>;
   saveDraft?: Maybe<SaveDraftResponse>;
+  saveSMimeCert?: Maybe<SmimeCertInfoResponse>;
   sendDeliveryReport?: Maybe<Scalars['Boolean']>;
   sendInviteReply?: Maybe<InviteReplyResponse>;
   sendMessage?: Maybe<SendMessageResponse>;
@@ -2909,6 +2910,12 @@ export type MutationSaveDraftArgs = {
 };
 
 
+export type MutationSaveSMimeCertArgs = {
+  password?: Maybe<Scalars['String']>;
+  upload: SaveSMimeCertInputUpload;
+};
+
+
 export type MutationSendDeliveryReportArgs = {
   messageId: Scalars['ID'];
 };
@@ -3285,6 +3292,7 @@ export type Query = {
   getPreferences?: Maybe<Preferences>;
   getReminders?: Maybe<RemindersResponse>;
   getRights?: Maybe<RightsResponse>;
+  getSMimeCertInfo?: Maybe<SmimeCertInfoResponse>;
   getSMimePublicCerts?: Maybe<SMimePublicCertsResponse>;
   getScratchCodes?: Maybe<ScratchCodes>;
   getSearchFolder?: Maybe<Folder>;
@@ -3467,6 +3475,11 @@ export type QueryGetRemindersArgs = {
 
 export type QueryGetRightsArgs = {
   input: GetRightsInput;
+};
+
+
+export type QueryGetSMimeCertInfoArgs = {
+  certId?: Maybe<Scalars['String']>;
 };
 
 
@@ -3768,6 +3781,10 @@ export type SaveMessageDataInput = {
   meta: Scalars['String'];
 };
 
+export type SaveSMimeCertInputUpload = {
+  id?: Maybe<Scalars['String']>;
+};
+
 export type ScratchCode = {
   __typename?: 'ScratchCode';
   scratchCode?: Maybe<Array<Maybe<ScratchCodeType>>>;
@@ -3984,6 +4001,66 @@ export type SizeConditionInput = {
 export type Skin = {
   __typename?: 'Skin';
   _content?: Maybe<Scalars['String']>;
+};
+
+export type SmimeCertInfoResponse = {
+  __typename?: 'SmimeCertInfoResponse';
+  certificates?: Maybe<Array<Maybe<SmimeCerts>>>;
+};
+
+export type SmimeCerts = {
+  __typename?: 'SmimeCerts';
+  default?: Maybe<Scalars['Boolean']>;
+  emailAddress?: Maybe<Scalars['String']>;
+  issuedBy?: Maybe<SmimeCertsIssuedBy>;
+  issuedTo?: Maybe<SmimeCertsIssuedTo>;
+  privateKeyId?: Maybe<Scalars['String']>;
+  publicCertificateId?: Maybe<Scalars['String']>;
+  signature?: Maybe<SmimeCertsSignature>;
+  subjectAltName?: Maybe<SmimeCertsSubjectAltName>;
+  validity?: Maybe<SmimeCertsValidity>;
+};
+
+export type SmimeCertsIssuedBy = {
+  __typename?: 'SmimeCertsIssuedBy';
+  commonName?: Maybe<Scalars['String']>;
+  country?: Maybe<Scalars['String']>;
+  emailAddress?: Maybe<Scalars['String']>;
+  locality?: Maybe<Scalars['String']>;
+  organizationName?: Maybe<Scalars['String']>;
+  state?: Maybe<Scalars['String']>;
+};
+
+export type SmimeCertsIssuedTo = {
+  __typename?: 'SmimeCertsIssuedTo';
+  commonName?: Maybe<Scalars['String']>;
+  country?: Maybe<Scalars['String']>;
+  emailAddress?: Maybe<Scalars['String']>;
+  organizationName?: Maybe<Scalars['String']>;
+  organizationUnit?: Maybe<Scalars['String']>;
+  state?: Maybe<Scalars['String']>;
+};
+
+export type SmimeCertsSignature = {
+  __typename?: 'SmimeCertsSignature';
+  algorithm?: Maybe<Scalars['String']>;
+  serialNo?: Maybe<Scalars['String']>;
+};
+
+export type SmimeCertsSubjectAltName = {
+  __typename?: 'SmimeCertsSubjectAltName';
+  rfc822Name?: Maybe<Array<Maybe<SmimeCertsSubjectRfc822Name>>>;
+};
+
+export type SmimeCertsSubjectRfc822Name = {
+  __typename?: 'SmimeCertsSubjectRfc822Name';
+  content?: Maybe<Scalars['String']>;
+};
+
+export type SmimeCertsValidity = {
+  __typename?: 'SmimeCertsValidity';
+  endDate?: Maybe<Scalars['Float']>;
+  startDate?: Maybe<Scalars['Float']>;
 };
 
 export type SnoozeInput = {

--- a/src/schema/schema.graphql
+++ b/src/schema/schema.graphql
@@ -513,6 +513,8 @@ type MessageInfo implements MailItem {
 	modifiedSequence: Float # ms
 	invitations: [InviteInfo] # inv
 	sortField: String # sf, Sort field used for cursor-based pagination
+	decryptionErrorCode: String
+	certificate: [SmimeCert]
 	mimeParts: [MimePart]
 	to: [EmailAddress]
 	from: [EmailAddress]
@@ -527,6 +529,8 @@ type MessageInfo implements MailItem {
 	share: [ShareNotification] # shr
 	replyType: String #rt
 	attributes: MessageAttributes
+	isEncrypted: Boolean
+	isSigned: Boolean
 	autoSendTime: Float
 	local: Boolean
 	part: String
@@ -2992,7 +2996,7 @@ type SMimePublicCertsResponse {
 	certs: [SMimePublicCerts]
 }
 
-type SmimeCertsIssuedBy {
+type SmimeCertIssuedBy {
 	country: String
 	commonName: String
 	emailAddress: String
@@ -3001,7 +3005,7 @@ type SmimeCertsIssuedBy {
 	state: String
 }
 
-type SmimeCertsIssuedTo {
+type SmimeCertIssuedTo {
 	country: String
 	commonName: String
 	emailAddress: String
@@ -3010,38 +3014,39 @@ type SmimeCertsIssuedTo {
 	state: String
 }
 
-type SmimeCertsSignature {
+type SmimeCertSignature {
 	algorithm: String
 	serialNo: String
 }
 
-type SmimeCertsSubjectRfc822Name {
+type SmimeCertSubjectRfc822Name {
 	content: String
 }
 
-type SmimeCertsSubjectAltName {
-	rfc822Name: [SmimeCertsSubjectRfc822Name]
+type SmimeCertSubjectAltName {
+	rfc822Name: [SmimeCertSubjectRfc822Name]
 }
 
-type SmimeCertsValidity {
+type SmimeCertValidity {
 	endDate: Float
 	startDate: Float
 }
 
-type SmimeCerts {
+type SmimeCert {
 	default: Boolean
 	emailAddress: String
-	issuedBy: SmimeCertsIssuedBy
-	issuedTo: SmimeCertsIssuedTo
+	issuedBy: SmimeCertIssuedBy
+	issuedTo: SmimeCertIssuedTo
 	publicCertificateId: String
 	privateKeyId: String
-	signature: SmimeCertsSignature
-	subjectAltName: SmimeCertsSubjectAltName
-	validity: SmimeCertsValidity
+	signature: SmimeCertSignature
+	subjectAltName: SmimeCertSubjectAltName
+	validity: SmimeCertValidity
+	errorCode: String
 }
 
 type SmimeCertInfoResponse {
-	certificates: [SmimeCerts]
+	certificates: [SmimeCert]
 }
 
 type SMimeMessage {

--- a/src/schema/schema.graphql
+++ b/src/schema/schema.graphql
@@ -3443,6 +3443,8 @@ type Mutation {
 	sendMessage(
 		message: SendMessageInput!
 		accountName: String
+		sign: Boolean
+		encrypt: Boolean
 	): SendMessageResponse
 	sendDeliveryReport(messageId: ID!): Boolean
 	sendInviteReply(inviteReply: InviteReplyInput!): InviteReplyResponse

--- a/src/schema/schema.graphql
+++ b/src/schema/schema.graphql
@@ -1644,6 +1644,7 @@ type Contact {
 	tagNames: String # tn
 	attributes: ContactAttributes
 	members: [ContactListMember]
+	certificate: [SmimeCert]
 }
 
 type OtherContactAttribute {

--- a/src/schema/schema.graphql
+++ b/src/schema/schema.graphql
@@ -2112,6 +2112,10 @@ input SendMessageInput {
 	inlineAttachments: [MimePartInput] #attach
 }
 
+input SaveSMimeCertInputUpload {
+	id: String
+}
+
 input CalendarItemInviteInput {
 	components: [CalendarItemInviteComponentInput]!
 }
@@ -2988,6 +2992,58 @@ type SMimePublicCertsResponse {
 	certs: [SMimePublicCerts]
 }
 
+type SmimeCertsIssuedBy {
+	country: String
+	commonName: String
+	emailAddress: String
+	locality: String
+	organizationName: String
+	state: String
+}
+
+type SmimeCertsIssuedTo {
+	country: String
+	commonName: String
+	emailAddress: String
+	organizationName: String
+	organizationUnit: String
+	state: String
+}
+
+type SmimeCertsSignature {
+	algorithm: String
+	serialNo: String
+}
+
+type SmimeCertsSubjectRfc822Name {
+	content: String
+}
+
+type SmimeCertsSubjectAltName {
+	rfc822Name: [SmimeCertsSubjectRfc822Name]
+}
+
+type SmimeCertsValidity {
+	endDate: Float
+	startDate: Float
+}
+
+type SmimeCerts {
+	default: Boolean
+	emailAddress: String
+	issuedBy: SmimeCertsIssuedBy
+	issuedTo: SmimeCertsIssuedTo
+	publicCertificateId: String
+	privateKeyId: String
+	signature: SmimeCertsSignature
+	subjectAltName: SmimeCertsSubjectAltName
+	validity: SmimeCertsValidity
+}
+
+type SmimeCertInfoResponse {
+	certificates: [SmimeCerts]
+}
+
 type SMimeMessage {
 	id: ID
 	content: String
@@ -3205,6 +3261,7 @@ type Query {
 		contactAddr: String!
 		store: String!
 	): SMimePublicCertsResponse
+	getSMimeCertInfo(certId: String): SmimeCertInfoResponse
 	getScratchCodes(username: String!): ScratchCodes
 	getSearchFolder: Folder
 	getTrustedDevices: GetTrustedDevicesResponse
@@ -3446,6 +3503,7 @@ type Mutation {
 		sign: Boolean
 		encrypt: Boolean
 	): SendMessageResponse
+	saveSMimeCert(upload: SaveSMimeCertInputUpload!, password: String): SmimeCertInfoResponse
 	sendDeliveryReport(messageId: ID!): Boolean
 	sendInviteReply(inviteReply: InviteReplyInput!): InviteReplyResponse
 	sendShareNotification(shareNotification: ShareNotificationInput!): Boolean

--- a/src/schema/schema.ts
+++ b/src/schema/schema.ts
@@ -30,6 +30,7 @@ import {
 	PreferencesInput,
 	PropertiesInput,
 	RevokeRightsInput,
+	SaveSMimeCertInputUpload,
 	SearchFolderInput,
 	SendMessageInput,
 	ShareNotificationInput,
@@ -169,6 +170,7 @@ export function createZimbraSchema(options: ZimbraSchemaOptions): {
 				getSearchFolder: client.getSearchFolder,
 				getSMimePublicCerts: (_, variables) =>
 					client.getSMimePublicCerts(variables as GetSMimePublicCertsOptions),
+				getSMimeCertInfo: client.getSMimeCertInfo,
 				getTrustedDevices: client.getTrustedDevices,
 				getDeviceStatus: client.getDeviceStatus,
 				getWorkingHours: (_, variables) => client.getWorkingHours(variables as WorkingHoursOptions),
@@ -375,6 +377,8 @@ export function createZimbraSchema(options: ZimbraSchemaOptions): {
 						sign as Boolean,
 						encrypt as Boolean
 					),
+				saveSMimeCert: (_, { upload, password }) =>
+					client.saveSMimeCert(upload as SaveSMimeCertInputUpload, password as string),
 				sendDeliveryReport: (_, { messageId }) => client.sendDeliveryReport(messageId),
 				uploadMessage: (_, { value }) => client.uploadMessage(value),
 				createTask: (_, { task }) => client.createTask(task as CalendarItemInput),

--- a/src/schema/schema.ts
+++ b/src/schema/schema.ts
@@ -368,10 +368,12 @@ export function createZimbraSchema(options: ZimbraSchemaOptions): {
 						message as SendMessageInput,
 						accountName as string
 					),
-				sendMessage: (_, { message, accountName }, context = {}) =>
+				sendMessage: (_, { message, accountName, sign = false, encrypt = false }, context = {}) =>
 					(context.local ? localStoreClient : client).sendMessage(
 						message as SendMessageInput,
-						accountName as string
+						accountName as string,
+						sign as Boolean,
+						encrypt as Boolean
 					),
 				sendDeliveryReport: (_, { messageId }) => client.sendDeliveryReport(messageId),
 				uploadMessage: (_, { value }) => client.uploadMessage(value),

--- a/src/utils/normalize-otherAttribute-contact.ts
+++ b/src/utils/normalize-otherAttribute-contact.ts
@@ -107,7 +107,7 @@ export function createContactBody(data: any) {
 		key !== 'other'
 			? contactAttrs.push({
 					name: key,
-					[key === 'image' ? 'aid' : 'content']: val
+					[key === 'image' || key === 'userCertificate' ? 'aid' : 'content']: val
 			  })
 			: forEach(val, otherValue =>
 					contactAttrs.push({


### PR DESCRIPTION
Creates SendSecureMsgRequest related graphql schema.
Adding facility to give necessary parameters like 'sign' and 'encrypt' with SendSecureMsgRequest.
'sign' will be included while user wants to just sign any particular mail.
'sign' and 'encrypt' both will be included while user wants to sign+encrypt any particular mail.