### PR TITLE
PREAPPS-6472: Show EML attachment in the attachment section.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ version: 2.1
 config: &config
   working_directory: ~/repo
   docker:
-    - image: cimg/node:lts
+    - image: cimg/node:14.18
 
 persist-workspace: &persist-workspace
   persist_to_workspace:

--- a/src/utils/normalize-mime-parts.ts
+++ b/src/utils/normalize-mime-parts.ts
@@ -24,7 +24,8 @@ function reduceMimeParts(
 	if (parts && parts.length) {
 		for (let i = 0; i < parts.length; i++) {
 			accumulator = iterator(parts[i], i, accumulator);
-			reduceMimeParts(parts[i], iterator, accumulator);
+			if (parts[i].contentType !== 'message/rfc822')
+				reduceMimeParts(parts[i], iterator, accumulator);
 		}
 	}
 


### PR DESCRIPTION
Below Issues fixed
**Issue**: If attached EML file contains attachments then message view is showing those attachment as well. 
_Expected_- Message preview should show EML file only it should not display attachment of EML.
**Issue**: build job failing due to issue with lts version of circleci image.