### PR TITLE
PREAPPS-6380 : Add-Remove certificate facility in contact.

### DIFF
--- a/src/normalize/entities.ts
+++ b/src/normalize/entities.ts
@@ -483,7 +483,8 @@ const contactFields = {
 	sf: 'sortField',
 	t: 'tags',
 	tn: 'tagNames',
-	_attrs: ['attributes', ContactAttributes]
+	_attrs: ['attributes', ContactAttributes],
+	certificate: ['certificate', SmimeCert]
 };
 
 const contactListMembers = new Entity({

--- a/src/schema/generated-schema-types.ts
+++ b/src/schema/generated-schema-types.ts
@@ -816,6 +816,7 @@ export enum ConnectionType {
 export type Contact = {
   __typename?: 'Contact';
   attributes?: Maybe<ContactAttributes>;
+  certificate?: Maybe<Array<Maybe<SmimeCert>>>;
   date?: Maybe<Scalars['Float']>;
   fileAsStr?: Maybe<Scalars['String']>;
   folderId?: Maybe<Scalars['ID']>;

--- a/src/schema/schema.graphql
+++ b/src/schema/schema.graphql
@@ -1643,6 +1643,7 @@ type Contact {
 	tagNames: String # tn
 	attributes: ContactAttributes
 	members: [ContactListMember]
+	certificate: [SmimeCert]
 }
 
 type OtherContactAttribute {

--- a/src/utils/normalize-otherAttribute-contact.ts
+++ b/src/utils/normalize-otherAttribute-contact.ts
@@ -87,7 +87,7 @@ export function createContactBody(data: any) {
 		key !== 'other'
 			? contactAttrs.push({
 					name: key,
-					[key === 'image' ? 'aid' : 'content']: val
+					[key === 'image' || key === 'userCertificate' ? 'aid' : 'content']: val
 			  })
 			: forEach(val, otherValue =>
 					contactAttrs.push({


### PR DESCRIPTION
Problem:
- There is no way for user to add/remove public certificate in case of server-smime.

Solution:
- User can add public certificate into contact.
- User can remove public certificate from contact.
- This facilities will be available via secure-mail zimlet.
- Introduced a zimlet-slot 'contact-add-server-smime-cert'.
- Using 'userCertificate' attribute of contact to set aid of uploaded certificate into contact.