### PR TITLE
ZBUG-2426: SAML SP-initiated logout does not work - zimbraWebClientLogoutURL

### DIFF
--- a/src/batch-client/index.ts
+++ b/src/batch-client/index.ts
@@ -541,7 +541,7 @@ export class ZimbraBatchClient {
 			},
 			singleRequest: true,
 			namespace: Namespace.Account
-		}).then(res => normalize(ClientInfoResponse)(res));
+		}).then(res => normalize(ClientInfoResponse)(mapValuesDeep(res, coerceStringToBoolean)));
 
 	public contactAction = (options: ActionOptions) => this.action(ActionType.contact, options);
 
@@ -849,6 +849,41 @@ export class ZimbraBatchClient {
 			namespace: Namespace.Account,
 			singleRequest: true
 		});
+
+	public endSessionBeaconRequest = (options: JsonRequestOptions) => {
+		const body = {
+			Body: {
+				EndSessionRequest: {
+					_jsns: Namespace.Account
+				}
+			},
+			Header: {
+				context: {
+					_jsns: Namespace.All,
+					csrfToken: this.csrfToken,
+					account: {
+						by: 'name',
+						_content: options.accountName
+					},
+					session: {
+						id: this.sessionId,
+						_content: this.sessionId
+					},
+					userAgent: this.userAgent
+				}
+			}
+		};
+
+		try {
+			const blob = new Blob([JSON.stringify(body)]);
+			if (navigator) {
+				// In zimbra desktop client navigator is null
+				navigator.sendBeacon(`${this.origin}/service/soap`, blob);
+			}
+		} catch (e) {
+			throw new Error('Error on endSessionBeaconRequest request' + e);
+		}
+	};
 
 	public folderAction = (options: ActionOptions) => this.action(ActionType.folder, options);
 

--- a/src/schema/generated-schema-types.ts
+++ b/src/schema/generated-schema-types.ts
@@ -792,6 +792,7 @@ export type ClientInfoAttributes = {
   zimbraFeatureResetPasswordStatus?: Maybe<ResetPasswordStatus>;
   zimbraWebClientLoginURL?: Maybe<Scalars['String']>;
   zimbraWebClientLogoutURL?: Maybe<Scalars['String']>;
+  zimbraWebClientSkipLogoff?: Maybe<Scalars['Boolean']>;
 };
 
 export type ClientInfoType = {

--- a/src/schema/schema.graphql
+++ b/src/schema/schema.graphql
@@ -485,6 +485,7 @@ interface MailItem {
 type ClientInfoAttributes {
 	zimbraWebClientLoginURL: String
 	zimbraWebClientLogoutURL: String
+	zimbraWebClientSkipLogoff: Boolean
 	zimbraFeatureResetPasswordStatus: ResetPasswordStatus
 }
 


### PR DESCRIPTION
- Created sendBeacon request to terminate session. This request will be called from zm-x-web directly when 'beforeunload' event trigger. See this https://github.com/ZimbraOS/zm-x-web/pull/3829/files#diff-e422e4a89b3245e4203985dfafed63e4e7a9abcb7bfc93c6ed161e75d36aeb9bR5