### PR TITLE
PREAPPS-6698:Modern UI - Users should not be allowed to use username in the password

### DIFF
--- a/src/batch-client/index.ts
+++ b/src/batch-client/index.ts
@@ -1629,7 +1629,7 @@ export class ZimbraBatchClient {
 				cancelResetPassword
 			},
 			singleRequest: true
-		});
+		}).then(res => mapValuesDeep(res, coerceStringToBoolean));
 
 	public resolve = (path: string) => `${this.origin}${path}`;
 

--- a/src/schema/generated-schema-types.ts
+++ b/src/schema/generated-schema-types.ts
@@ -128,6 +128,7 @@ export type AccountInfoAttrs = {
   zimbraMailBlacklistMaxNumEntries?: Maybe<Scalars['Int']>;
   zimbraMailQuota?: Maybe<Scalars['String']>;
   zimbraMtaMaxMessageSize?: Maybe<Scalars['Float']>;
+  zimbraPasswordAllowUsername?: Maybe<Scalars['Boolean']>;
   zimbraPasswordAllowedChars?: Maybe<Scalars['String']>;
   zimbraPasswordAllowedPunctuationChars?: Maybe<Scalars['String']>;
   zimbraPasswordBlockCommonEnabled?: Maybe<Scalars['Boolean']>;

--- a/src/schema/schema.graphql
+++ b/src/schema/schema.graphql
@@ -1310,6 +1310,7 @@ type AccountInfoAttrs {
 	zimbraFeatureMobileSyncEnabled: Boolean
 	zimbraFeatureRelatedContactsEnabled: Boolean
 	zimbraFeatureMailForwardingInFiltersEnabled: Boolean
+	zimbraPasswordAllowUsername: Boolean
 	zimbraPasswordBlockCommonEnabled: Boolean
 	zimbraPasswordMinAlphaChars: Int
 	zimbraPasswordMinNumericChars: Int


### PR DESCRIPTION
-Added zimbraPasswordAllowUsername to the schema of AccountInfoAttrs