### PR TITLE
PREAPPS-6581 Import from @apollo/client/core instead of @apollo/client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,10 +41,27 @@
 						"tslib": "^2.1.0"
 					}
 				},
+				"ts-invariant": {
+					"version": "0.9.4",
+					"resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.9.4.tgz",
+					"integrity": "sha512-63jtX/ZSwnUNi/WhXjnK8kz4cHHpYS60AnmA6ixz17l7E12a5puCWFlNpkne5Rl0J8TBPVHpGjsj4fxs8ObVLQ==",
+					"requires": {
+						"tslib": "^2.1.0"
+					}
+				},
 				"tslib": {
 					"version": "2.3.1",
 					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
 					"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+				},
+				"zen-observable-ts": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.1.0.tgz",
+					"integrity": "sha512-1h4zlLSqI2cRLPJUHJFL8bCWHhkpuXkF+dbGkRaWjgDIG26DmzyshUMrdV/rL3UnR+mhaX4fRq8LPouq0MYYIA==",
+					"requires": {
+						"@types/zen-observable": "0.8.3",
+						"zen-observable": "0.8.15"
+					}
 				}
 			}
 		},
@@ -1914,22 +1931,22 @@
 			}
 		},
 		"@graphql-codegen/typescript": {
-			"version": "2.4.10",
-			"resolved": "https://registry.npmjs.org/@graphql-codegen/typescript/-/typescript-2.4.10.tgz",
-			"integrity": "sha512-Wr/GzYrpY8d8I9+ZFSkNefOpYaMtBL2s2E79IoEOLAqXHUWxM0reBwkEk4oHtLw27AmaXgngajPFPaO5QAhotQ==",
+			"version": "2.4.11",
+			"resolved": "https://registry.npmjs.org/@graphql-codegen/typescript/-/typescript-2.4.11.tgz",
+			"integrity": "sha512-K3oDLPJRH9Wgpg9TOvb7L+xrJZ8HxkIzV2umqGn54c+8DQjvnRFBIYRO0THgUBMnEauE2sEy6RZkGHGfgQUruA==",
 			"dev": true,
 			"requires": {
 				"@graphql-codegen/plugin-helpers": "^2.4.0",
 				"@graphql-codegen/schema-ast": "^2.4.1",
-				"@graphql-codegen/visitor-plugin-common": "2.7.6",
+				"@graphql-codegen/visitor-plugin-common": "2.8.0",
 				"auto-bind": "~4.0.0",
 				"tslib": "~2.4.0"
 			}
 		},
 		"@graphql-codegen/visitor-plugin-common": {
-			"version": "2.7.6",
-			"resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-2.7.6.tgz",
-			"integrity": "sha512-XHeopd8z5UE2alv8nn2LrF+qpfRpldeqHOwrmLmlzyCWcuz5vMiZ08CgtE03micQNQJg5s8Z9m72S3FrvBUoAA==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-2.8.0.tgz",
+			"integrity": "sha512-29MOaxBog7qaEhmeCzJn2mONSbcA+slCTzHN4nJ3aZl4KrC9V32rXlQpG5x0qHbFQ1LaG1f5gPO83xbiAeMBIw==",
 			"dev": true,
 			"requires": {
 				"@graphql-codegen/plugin-helpers": "^2.4.0",
@@ -2179,6 +2196,7 @@
 			"version": "8.2.10",
 			"resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.2.10.tgz",
 			"integrity": "sha512-wpg22seOTNfkIO8jFAgo8w1BsT3IS2OTMpkCNf+dvcKSP09SVidYCOliyWHgjDCmpCrvvSjOX855NUKDx/Biew==",
+			"dev": true,
 			"requires": {
 				"@graphql-tools/utils": "8.6.9",
 				"tslib": "~2.3.0"
@@ -2187,7 +2205,8 @@
 				"tslib": {
 					"version": "2.3.1",
 					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-					"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+					"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+					"dev": true
 				}
 			}
 		},
@@ -2318,21 +2337,24 @@
 			}
 		},
 		"@graphql-tools/relay-operation-optimizer": {
-			"version": "6.4.9",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/relay-operation-optimizer/-/relay-operation-optimizer-6.4.9.tgz",
-			"integrity": "sha512-fHMR1bNyx+ryBnmtXWnYmxvQLEx0O3yIG0MTVB1Mp6GlsyKTGI3O9njvjv0EI2JmCszs1uakT/6BW0LO37E6tQ==",
+			"version": "6.4.10",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/relay-operation-optimizer/-/relay-operation-optimizer-6.4.10.tgz",
+			"integrity": "sha512-a5wDdXP7MmwZDy9R8+RZ0ajJBWX1Lk9sIG6uSIo5G/LnGpXncgBhKpJf5r6rOf0zsFLWnAkYm/dCDMpFaGE/Yw==",
 			"dev": true,
 			"requires": {
-				"@graphql-tools/utils": "8.6.9",
+				"@graphql-tools/utils": "8.6.10",
 				"relay-compiler": "12.0.0",
-				"tslib": "~2.3.0"
+				"tslib": "~2.4.0"
 			},
 			"dependencies": {
-				"tslib": {
-					"version": "2.3.1",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-					"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
-					"dev": true
+				"@graphql-tools/utils": {
+					"version": "8.6.10",
+					"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.10.tgz",
+					"integrity": "sha512-bJH9qwuyM3BP0PTU6/lvBDkk6jdEIOn+dbyk4pHMVNnvbJ1gZQwo62To8SHxxaUTus8OMhhVPSh9ApWXREURcg==",
+					"dev": true,
+					"requires": {
+						"tslib": "~2.4.0"
+					}
 				}
 			}
 		},
@@ -2340,6 +2362,7 @@
 			"version": "8.3.10",
 			"resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-8.3.10.tgz",
 			"integrity": "sha512-tfhjSTi3OzheDrVzG7rkPZg2BbQjmZRLM2vvQoM2b1TnUwgUIbpAgcnf+AWDLRsoCOWlezeLgij1BLeAR0Q0jg==",
+			"dev": true,
 			"requires": {
 				"@graphql-tools/merge": "8.2.10",
 				"@graphql-tools/utils": "8.6.9",
@@ -2350,7 +2373,8 @@
 				"tslib": {
 					"version": "2.3.1",
 					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-					"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+					"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+					"dev": true
 				}
 			}
 		},
@@ -2398,6 +2422,7 @@
 			"version": "8.6.9",
 			"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.9.tgz",
 			"integrity": "sha512-Z1X4d4GCT81+8CSt6SgU4t1w1UAUsAIRb67mI90k/zAs+ArkB95iE3bWXuJCUmd1+r8DGGtmUNOArtd6wkt+OQ==",
+			"dev": true,
 			"requires": {
 				"tslib": "~2.3.0"
 			},
@@ -2405,7 +2430,8 @@
 				"tslib": {
 					"version": "2.3.1",
 					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-					"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+					"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+					"dev": true
 				}
 			}
 		},
@@ -2431,9 +2457,9 @@
 			}
 		},
 		"@graphql-typed-document-node/core": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.0.tgz",
-			"integrity": "sha512-wYn6r8zVZyQJ6rQaALBEln5B1pzxb9shV5Ef97kTvn6yVGrqyXVnDqnU24MXnFubR+rZjBY9NWuxX3FB2sTsjg=="
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.1.tgz",
+			"integrity": "sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg=="
 		},
 		"@iarna/toml": {
 			"version": "2.2.5",
@@ -2725,9 +2751,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "17.0.31",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.31.tgz",
-			"integrity": "sha512-AR0x5HbXGqkEx9CadRH3EBYx/VkiUgZIhP4wvPn/+5KIsgpNoyFaRlVe0Zlx9gRtg8fA06a9tskE2MSN7TcG4Q==",
+			"version": "17.0.32",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.32.tgz",
+			"integrity": "sha512-eAIcfAvhf/BkHcf4pkLJ7ECpBAhh9kcxRBpip9cTiO+hf+aJrsxYxBeS6OXvOd9WqNAJmavXVpZvY1rBjNsXmw==",
 			"dev": true
 		},
 		"@types/parse-json": {
@@ -2789,13 +2815,6 @@
 			"integrity": "sha512-LOmVnY1iTU2D8tv4Xf6MVMZZ+juIJ87Kt/plMijjN20NMAXGmH4u8bS1t0uT74cZ5gwpocYueV58YwyI8y+GKw==",
 			"requires": {
 				"tslib": "^2.3.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.3.1",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-					"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
-				}
 			}
 		},
 		"@wry/equality": {
@@ -2804,13 +2823,6 @@
 			"integrity": "sha512-oVMxbUXL48EV/C0/M7gLVsoK6qRHPS85x8zECofEZOVvxGmIPLA9o5Z27cc2PoAyZz1S2VoM2A7FLAnpfGlneA==",
 			"requires": {
 				"tslib": "^2.3.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.3.1",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-					"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
-				}
 			}
 		},
 		"@wry/trie": {
@@ -2819,13 +2831,6 @@
 			"integrity": "sha512-WwB53ikYudh9pIorgxrkHKrQZcCqNM/Q/bDzZBffEaGUKGuHrRb3zZUT9Sh2qw9yogC7SsdRmQ1ER0pqvd3bfw==",
 			"requires": {
 				"tslib": "^2.3.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.3.1",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-					"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
-				}
 			}
 		},
 		"JSONStream": {
@@ -6109,19 +6114,42 @@
 			"dev": true
 		},
 		"graphql-tools": {
-			"version": "8.2.8",
-			"resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-8.2.8.tgz",
-			"integrity": "sha512-CqavuYcbWb71WiA73GIilJH/dovy77pbv0RG6KemppDUwzu80hHPy7c71kE1w+PQftvgS5PBC89GNqx6YC4hmw==",
+			"version": "8.2.9",
+			"resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-8.2.9.tgz",
+			"integrity": "sha512-ZDu5MFt8Cc+LM8EfS+ie8ueKrAZ5R/iLzS6AkmS0KLc9J6gJ3hLezJszVtoV9OS4kajA1XIfZ8jeoQ8000OJog==",
 			"requires": {
-				"@apollo/client": "~3.2.5 || ~3.3.0 || ~3.4.0 || ~3.5.0",
-				"@graphql-tools/schema": "8.3.10",
-				"tslib": "~2.3.0"
+				"@apollo/client": "~3.2.5 || ~3.3.0 || ~3.4.0 || ~3.5.0 || ~3.6.0",
+				"@graphql-tools/schema": "8.3.11",
+				"tslib": "~2.4.0"
 			},
 			"dependencies": {
-				"tslib": {
-					"version": "2.3.1",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-					"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+				"@graphql-tools/merge": {
+					"version": "8.2.11",
+					"resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.2.11.tgz",
+					"integrity": "sha512-fsjJVdsk9GV1jj1Ed2AKLlHYlsf0ZadTK8X5KxFRE1ZSnKqh56BLVX93JrtOIAnsiHkwOK2TC43HGhApF1swpQ==",
+					"requires": {
+						"@graphql-tools/utils": "8.6.10",
+						"tslib": "~2.4.0"
+					}
+				},
+				"@graphql-tools/schema": {
+					"version": "8.3.11",
+					"resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-8.3.11.tgz",
+					"integrity": "sha512-esMEnbyXbp8B5VEI4o395+x0G7Qmz3JSX5onFBF8HeLYcqWJasY5vBuWkO18VxrZpEnvnryodP6Y00bVag9O3Q==",
+					"requires": {
+						"@graphql-tools/merge": "8.2.11",
+						"@graphql-tools/utils": "8.6.10",
+						"tslib": "~2.4.0",
+						"value-or-promise": "1.0.11"
+					}
+				},
+				"@graphql-tools/utils": {
+					"version": "8.6.10",
+					"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.10.tgz",
+					"integrity": "sha512-bJH9qwuyM3BP0PTU6/lvBDkk6jdEIOn+dbyk4pHMVNnvbJ1gZQwo62To8SHxxaUTus8OMhhVPSh9ApWXREURcg==",
+					"requires": {
+						"tslib": "~2.4.0"
+					}
 				}
 			}
 		},
@@ -6277,9 +6305,9 @@
 			"dev": true
 		},
 		"husky": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/husky/-/husky-8.0.0.tgz",
-			"integrity": "sha512-4qbE/5dzNDNxFEkX9MNRPKl5+omTXQzdILCUWiqG/lWIAioiM5vln265/l6I2Zx8gpW8l1ukZwGQeCFbBZ6+6w==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/husky/-/husky-8.0.1.tgz",
+			"integrity": "sha512-xs7/chUH/CKdOCs7Zy0Aev9e/dKOMZf3K1Az1nar3tzlv0jfqnYtu235bstsWTmXOR0EfINrPa97yy4Lz6RiKw==",
 			"dev": true
 		},
 		"iconv-lite": {
@@ -8501,13 +8529,13 @@
 			}
 		},
 		"prop-types": {
-			"version": "15.7.2",
-			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-			"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+			"version": "15.8.1",
+			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+			"integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
 			"requires": {
 				"loose-envify": "^1.4.0",
 				"object-assign": "^4.1.1",
-				"react-is": "^16.8.1"
+				"react-is": "^16.13.1"
 			}
 		},
 		"pseudomap": {
@@ -9472,21 +9500,6 @@
 			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
 			"dev": true
 		},
-		"ts-invariant": {
-			"version": "0.9.3",
-			"resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.9.3.tgz",
-			"integrity": "sha512-HinBlTbFslQI0OHP07JLsSXPibSegec6r9ai5xxq/qHYCsIQbzpymLpDhAUsnXcSrDEcd0L62L8vsOEdzM0qlA==",
-			"requires": {
-				"tslib": "^2.1.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.3.1",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-					"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
-				}
-			}
-		},
 		"ts-log": {
 			"version": "2.2.4",
 			"resolved": "https://registry.npmjs.org/ts-log/-/ts-log-2.2.4.tgz",
@@ -9510,8 +9523,7 @@
 		"tslib": {
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-			"dev": true
+			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
 		},
 		"tslint": {
 			"version": "6.1.3",
@@ -9615,9 +9627,9 @@
 			"dev": true
 		},
 		"uglify-js": {
-			"version": "3.15.4",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.4.tgz",
-			"integrity": "sha512-vMOPGDuvXecPs34V74qDKk4iJ/SN4vL3Ow/23ixafENYvtrNvtbcgUeugTcUGRGsOF/5fU8/NYSL5Hyb3l1OJA==",
+			"version": "3.15.5",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.5.tgz",
+			"integrity": "sha512-hNM5q5GbBRB5xB+PMqVRcgYe4c8jbyZ1pzZhS6jbq54/4F2gFK869ZheiE5A8/t+W5jtTNpWef/5Q9zk639FNQ==",
 			"dev": true
 		},
 		"unc-path-regex": {
@@ -10039,15 +10051,6 @@
 			"version": "0.8.15",
 			"resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
 			"integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
-		},
-		"zen-observable-ts": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.1.0.tgz",
-			"integrity": "sha512-1h4zlLSqI2cRLPJUHJFL8bCWHhkpuXkF+dbGkRaWjgDIG26DmzyshUMrdV/rL3UnR+mhaX4fRq8LPouq0MYYIA==",
-			"requires": {
-				"@types/zen-observable": "0.8.3",
-				"zen-observable": "0.8.15"
-			}
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@apollo/client": "^3.4.16",
     "dataloader": "^2.1.0",
     "graphql": "^15.8.0",
-    "graphql-tools": "^8.2.8",
+    "graphql-tools": "^8.2.9",
     "lodash": "^4.17.21",
     "mitt": "^3.0.0"
   },
@@ -58,21 +58,21 @@
     "@babel/preset-typescript": "^7.16.7",
     "@babel/register": "^7.17.7",
     "@graphql-codegen/cli": "^2.6.2",
-    "@graphql-codegen/typescript": "^2.4.10",
+    "@graphql-codegen/typescript": "^2.4.11",
     "@rollup/plugin-babel": "^5.3.1",
     "@rollup/plugin-commonjs": "^22.0.0",
     "@rollup/plugin-node-resolve": "^13.3.0",
     "@rollup/plugin-typescript": "^8.3.2",
     "@types/graphql": "^14.5.0",
     "@types/lodash": "^4.14.182",
-    "@types/node": "^17.0.31",
+    "@types/node": "^17.0.32",
     "@types/whatwg-fetch": "^0.0.33",
     "audit-ci": "^6.2.0",
     "babel-plugin-lodash": "^3.3.4",
     "chai": "^4.3.6",
     "copyfiles": "^2.4.1",
     "cross-var": "^1.1.0",
-    "husky": "^8.0.0",
+    "husky": "^8.0.1",
     "is-ci": "^3.0.1",
     "lint-staged": "^12.4.1",
     "mocha": "^10.0.0",
@@ -87,6 +87,6 @@
     "tslint-config-prettier": "^1.18.0",
     "tslint-plugin-prettier": "^2.3.0",
     "typescript": "^4.6.4",
-    "uglify-js": "^3.15.4"
+    "uglify-js": "^3.15.5"
   }
 }

--- a/src/apollo/local-batch-link.ts
+++ b/src/apollo/local-batch-link.ts
@@ -1,4 +1,4 @@
-import { ApolloLink, FetchResult, Observable, Operation } from '@apollo/client';
+import { ApolloLink, FetchResult, Observable, Operation } from '@apollo/client/core';
 import { BatchLink } from '@apollo/client/link/batch';
 import { graphql, print } from 'graphql';
 import events from 'mitt';

--- a/src/apollo/offline-queue-link/index.ts
+++ b/src/apollo/offline-queue-link/index.ts
@@ -1,4 +1,11 @@
-import { ApolloLink, FetchResult, NextLink, Observable, Observer, Operation } from '@apollo/client';
+import {
+	ApolloLink,
+	FetchResult,
+	NextLink,
+	Observable,
+	Observer,
+	Operation
+} from '@apollo/client/core';
 
 import { SyncOfflineOperations } from '../sync-offline-operations';
 import { OfflineQueueLinkOptions, OperationEntry, StorageProvider } from './types';

--- a/src/apollo/offline-queue-link/types.ts
+++ b/src/apollo/offline-queue-link/types.ts
@@ -1,5 +1,4 @@
-import { FetchResult, NextLink, Operation } from '@apollo/client';
-import { Observer } from '@apollo/client';
+import { FetchResult, NextLink, Observer, Operation } from '@apollo/client/core';
 
 export interface OfflineQueueLinkOptions {
 	isOpen?: boolean;

--- a/src/apollo/offline-queue-link/util.ts
+++ b/src/apollo/offline-queue-link/util.ts
@@ -1,4 +1,4 @@
-import { Operation } from '@apollo/client';
+import { Operation } from '@apollo/client/core';
 import get from 'lodash/get';
 import { OfflineOperationEntry, OperationEntry } from './types';
 

--- a/src/apollo/zimbra-in-memory-cache.ts
+++ b/src/apollo/zimbra-in-memory-cache.ts
@@ -1,4 +1,4 @@
-import { defaultDataIdFromObject, InMemoryCache, InMemoryCacheConfig } from '@apollo/client';
+import { defaultDataIdFromObject, InMemoryCache, InMemoryCacheConfig } from '@apollo/client/core';
 import get from 'lodash/get';
 
 const dataIdFromPath = (result: any, path: string) => {

--- a/src/schema/session-handler.ts
+++ b/src/schema/session-handler.ts
@@ -1,4 +1,4 @@
-import { gql } from '@apollo/client';
+import { gql } from '@apollo/client/core';
 import get from 'lodash/get';
 import { ZimbraInMemoryCache } from '../apollo/zimbra-in-memory-cache';
 import { ZimbraSessionOptions } from './types';


### PR DESCRIPTION
- As per https://github.com/apollographql/apollo-client/issues/7005, if we use @apollo/client imports then it includes react related packages as well, but that gives problem for us as this package is used inside sync module also which is executed inside node environment and hence doesn't have react library present