### PR TITLE
PREAPPS-7160 add adminDelegated attribute in AccountInfo schema

### DIFF
--- a/src/schema/generated-schema-types.ts
+++ b/src/schema/generated-schema-types.ts
@@ -58,6 +58,7 @@ export type AccountCos = {
 
 export type AccountInfo = {
   __typename?: 'AccountInfo';
+  adminDelegated?: Maybe<Scalars['Boolean']>;
   attrs?: Maybe<AccountInfoAttrs>;
   changePasswordURL?: Maybe<Scalars['String']>;
   cos?: Maybe<AccountCos>;
@@ -4007,7 +4008,7 @@ export type SignatureContentInput = {
 };
 
 export type SignatureInput = {
-  content?: InputMaybe<SignatureContentInput>;
+  content?: InputMaybe<Array<InputMaybe<SignatureContentInput>>>;
   contentId?: InputMaybe<Scalars['String']>;
   id?: InputMaybe<Scalars['ID']>;
   name?: InputMaybe<Scalars['String']>;

--- a/src/schema/schema.graphql
+++ b/src/schema/schema.graphql
@@ -1232,6 +1232,7 @@ type AccountInfo {
 	zimlets: AccountZimlet
 	cos: AccountCos
 	pasteitcleanedEnabled: Boolean
+	adminDelegated: Boolean
 }
 
 type OnlyEmailAddress {


### PR DESCRIPTION
We need to check whether user is logged in through delegated admin access or not. Hence adding the relevant attribute in the schema.