### PR TITLE
PREAPPS-7368: Implement Support Inline images in Signatures

### DIFF
--- a/src/schema/generated-schema-types.ts
+++ b/src/schema/generated-schema-types.ts
@@ -337,6 +337,26 @@ export type AppointmentInfo = {
   invitations?: Maybe<Array<Maybe<Invitation>>>;
 };
 
+export type AttachDoc = {
+  __typename?: 'AttachDoc';
+  doc?: Maybe<Array<Maybe<AttachDocs>>>;
+};
+
+export type AttachDocInput = {
+  doc?: InputMaybe<Array<InputMaybe<AttachDocsInput>>>;
+};
+
+export type AttachDocs = {
+  __typename?: 'AttachDocs';
+  optional?: Maybe<Scalars['Int']>;
+  path?: Maybe<Scalars['String']>;
+};
+
+export type AttachDocsInput = {
+  optional?: InputMaybe<Scalars['Int']>;
+  path?: InputMaybe<Scalars['String']>;
+};
+
 export type Attachment = {
   __typename?: 'Attachment';
   content?: Maybe<Scalars['String']>;
@@ -345,6 +365,8 @@ export type Attachment = {
 
 export type AttachmentInput = {
   attachmentId?: InputMaybe<Scalars['String']>;
+  cd?: InputMaybe<Scalars['String']>;
+  ct?: InputMaybe<Scalars['String']>;
   documents?: InputMaybe<Array<InputMaybe<DocumentInput>>>;
   existingAttachments?: InputMaybe<Array<InputMaybe<ExistingAttachmentInput>>>;
   messages?: InputMaybe<Array<InputMaybe<EmlInput>>>;
@@ -1317,6 +1339,8 @@ export type DocumentActionData = {
 
 export type DocumentInput = {
   id?: InputMaybe<Scalars['ID']>;
+  optional?: InputMaybe<Scalars['Int']>;
+  path?: InputMaybe<Scalars['String']>;
 };
 
 export type DtTimeInfo = {
@@ -2310,6 +2334,7 @@ export type MimeHeaderConditionInput = {
 
 export type MimePart = {
   __typename?: 'MimePart';
+  attach?: Maybe<AttachDoc>;
   base64?: Maybe<Scalars['String']>;
   body?: Maybe<Scalars['Boolean']>;
   content?: Maybe<Scalars['String']>;
@@ -2327,6 +2352,7 @@ export type MimePart = {
 };
 
 export type MimePartInput = {
+  attach?: InputMaybe<AttachDocInput>;
   attachments?: InputMaybe<Array<InputMaybe<AttachmentInput>>>;
   base64?: InputMaybe<Scalars['String']>;
   body?: InputMaybe<Scalars['Boolean']>;

--- a/src/schema/schema.graphql
+++ b/src/schema/schema.graphql
@@ -2021,6 +2021,25 @@ type MimePart {
 	messageId: ID
 	base64: String
 	truncated: Boolean
+	attach: AttachDoc
+}
+
+type AttachDoc {
+	doc: [AttachDocs]
+}
+
+type AttachDocs {
+	path: String
+	optional: Int
+}
+
+input AttachDocInput {
+	doc: [AttachDocsInput]
+}
+
+input AttachDocsInput {
+	path: String
+	optional: Int
 }
 
 type ActionData {
@@ -2049,6 +2068,7 @@ input MimePartInput {
 	attachments: [AttachmentInput]
 	base64: String,
 	truncated: Boolean
+	attach: AttachDocInput
 }
 
 input ExistingAttachmentInput {
@@ -2058,6 +2078,8 @@ input ExistingAttachmentInput {
 
 input DocumentInput {
 	id: ID
+	path: String
+	optional: Int
 }
 
 input EMLInput {
@@ -2069,6 +2091,8 @@ input AttachmentInput {
 	documents: [DocumentInput]
 	messages: [EMLInput]
 	existingAttachments: [ExistingAttachmentInput]
+	ct: String
+	cd: String
 }
 
 type AutoCompleteResponse {


### PR DESCRIPTION
#### Changes

- `src/utils/normalize-mime-parts.ts` lines 113 to 144: Fix for the issue - In Classic UI, create a draft message containing a signature with an inline image. Open the same draft in Modern UI, the signature image is displayed as an external attachment.