### PR TITLE
PREAPPS-7554: Distribution list is missing in the left sidebar of contact vertical

### DIFF
--- a/src/schema/generated-schema-types.ts
+++ b/src/schema/generated-schema-types.ts
@@ -97,6 +97,7 @@ export type AccountInfoAttrs = {
   zimbraFeatureConversationsEnabled?: Maybe<Scalars['Boolean']>;
   zimbraFeatureDiscardInFiltersEnabled?: Maybe<Scalars['Boolean']>;
   zimbraFeatureDistributionListExpandMembersEnabled?: Maybe<Scalars['Boolean']>;
+  zimbraFeatureDistributionListFolderEnabled?: Maybe<Scalars['Boolean']>;
   zimbraFeatureDocumentEditingEnabled?: Maybe<Scalars['Boolean']>;
   zimbraFeatureExportFolderEnabled?: Maybe<Scalars['Boolean']>;
   zimbraFeatureFiltersEnabled?: Maybe<Scalars['Boolean']>;

--- a/src/schema/schema.graphql
+++ b/src/schema/schema.graphql
@@ -1442,6 +1442,7 @@ type AccountInfoAttrs {
 	zimbraFeatureExportFolderEnabled: Boolean
 	zimbraFeatureGroupCalendarEnabled: Boolean
 	zimbraFeatureDistributionListExpandMembersEnabled: Boolean
+	zimbraFeatureDistributionListFolderEnabled: Boolean
 }
 
 type AccountCos {


### PR DESCRIPTION
- Added zimbraFeatureDistributionListFolderEnabled attribute in AccountInfoAttrs