### PR TITLE
ZBUG-3829 Fix error when showing mails which doesn't contain html content

### DIFF
--- a/src/utils/normalize-mime-parts.ts
+++ b/src/utils/normalize-mime-parts.ts
@@ -105,7 +105,7 @@ export function normalizeMimeParts(
 				type = normalizeType(part.contentType),
 				disposition = normalizeDisposition(part.contentDisposition),
 				parts = part.mimeParts,
-				content = part.content || ''; //getPartContent(part);
+				content = part?.content || ''; //getPartContent(part);
 
 			// obey scapi's isBody flag:
 			if (isBody) acc.body = content;
@@ -127,7 +127,7 @@ export function normalizeMimeParts(
 						~subpart.contentType.indexOf('image/') &&
 						subpart.contentDisposition === 'attachment' &&
 						subpart.contentId &&
-						htmlPart.content
+						htmlPart?.content
 					) {
 						// remove angle brackets from <contentId>
 						const contentId = subpart.contentId.slice(1, -1);


### PR DESCRIPTION
- Some mimes are having text/html part but it doesn't contain any data, in this case JS error was getting generated and because of that Modern UI was not able to display mail contents