### PR TITLE
PREAPPS-7688: Show Distribution List attributes in reading pane of contact vertical when user select the DL from left sidenav

### DIFF
--- a/src/schema/generated-schema-types.ts
+++ b/src/schema/generated-schema-types.ts
@@ -874,6 +874,7 @@ export type Contact = {
   fileAsStr?: Maybe<Scalars['String']['output']>;
   folderId?: Maybe<Scalars['ID']['output']>;
   id: Scalars['ID']['output'];
+  isOwner?: Maybe<Scalars['Boolean']['output']>;
   memberOf?: Maybe<Scalars['String']['output']>;
   members?: Maybe<Array<Maybe<ContactListMember>>>;
   revision?: Maybe<Scalars['Float']['output']>;

--- a/src/schema/schema.graphql
+++ b/src/schema/schema.graphql
@@ -1808,6 +1808,7 @@ type Contact {
 	attributes: ContactAttributes
 	members: [ContactListMember]
 	certificate: [SmimeCert]
+	isOwner: Boolean
 }
 
 type OtherContactAttribute {


### PR DESCRIPTION
- Added isOwner info in Contact type

PR for [zm-x-web](https://github.com/Zimbra/zm-x-web/pull/4907)