### PR TITLE
PREAPPS-7737: merge emailAddresses field in cache in order to use cached message response in modernUI

### DIFF
--- a/src/apollo/types.ts
+++ b/src/apollo/types.ts
@@ -5,3 +5,12 @@ export interface LocalBatchLinkOptions extends BatchLink.Options {
 	context?: any;
 	schema: GraphQLSchema;
 }
+
+export interface EmailAddress {
+	__typename?: 'EmailAddress';
+	address?: string;
+	displayName?: string;
+	isGroup?: boolean | null;
+	name?: string;
+	type?: string;
+}

--- a/src/apollo/zimbra-in-memory-cache.ts
+++ b/src/apollo/zimbra-in-memory-cache.ts
@@ -1,5 +1,8 @@
 import { defaultDataIdFromObject, InMemoryCache, InMemoryCacheConfig } from '@apollo/client/core';
 import get from 'lodash/get';
+import isEqual from 'lodash/isEqual';
+import uniqWith from 'lodash/uniqWith';
+import { EmailAddress } from './types';
 
 const dataIdFromPath = (result: any, path: string) => {
 	if (result.__typename) {
@@ -93,10 +96,9 @@ const typePolicies = {
 	MessageInfo: {
 		fields: {
 			emailAddresses: {
-				// @TODO ideally we should write proper merge function here,
-				// but as our app is already handling at caller level
-				// we are just overwriting cache data here
-				merge: false
+				merge(existing: EmailAddress[], incoming: EmailAddress[]) {
+					return uniqWith([...(existing || []), ...(incoming || [])], isEqual);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
We are using cached data for messages in message view. The related changes are in this PR - https://github.com/Zimbra/zm-x-web/pull/4970
Since the cached data is used it exposed couple of issues mainly because the emailAddress field cached from the GetMsg API call was getting overridden by the same field cached by the message search request. This is fixed by specifying how to cache email address field.