### PR TITLE
PREAPPS-8008: Added the zimbraPrefHideMuteConvModal flag in Mailbox Metadata to control the show/hide functionality of the mute conversation modal

### DIFF
--- a/src/schema/schema.graphql
+++ b/src/schema/schema.graphql
@@ -2116,6 +2116,7 @@ type MailboxMetadataAttrs {
 	zimbraPrefSMIMEDefaultSetting: String
 	zimbraPrefSMIMELastOperation: String
 	zimbraPrefContactSourceFolderID: String
+	zimbraPrefHideMuteConvModal: Boolean
 }
 
 type MailboxMetadataMeta {
@@ -2149,6 +2150,7 @@ input MailboxMetadataSectionAttrsInput {
 	zimbraPrefSMIMEDefaultSetting: String
 	zimbraPrefSMIMELastOperation: String
 	zimbraPrefContactSourceFolderID: String
+	zimbraPrefHideMuteConvModal: Boolean
 }
 
 type MimePart {


### PR DESCRIPTION
…etadata to control the show/hide functionality of the mute conversation modal