### PR TITLE
PREAPPS-8066 Remove ignoreSameSite in Auth Requests

### DIFF
--- a/src/batch-client/index.ts
+++ b/src/batch-client/index.ts
@@ -860,8 +860,7 @@ export class ZimbraBatchClient {
 		password,
 		authToken,
 		twoFactorCode,
-		csrfTokenSecured,
-		ignoreSameSite
+		csrfTokenSecured
 	}: EnableTwoFactorAuthInput) =>
 		this.jsonRequest({
 			name: 'EnableTwoFactorAuth',
@@ -894,7 +893,6 @@ export class ZimbraBatchClient {
 						_content: twoFactorCode
 					}
 				}),
-				...(ignoreSameSite && { ignoreSameSite }),
 				csrfTokenSecured
 			},
 			namespace: Namespace.Account,
@@ -1481,8 +1479,7 @@ export class ZimbraBatchClient {
 		persistAuthTokenCookie,
 		twoFactorCode,
 		deviceTrusted,
-		csrfTokenSecured,
-		ignoreSameSite
+		csrfTokenSecured
 	}: LoginOptions) =>
 		this.jsonRequest({
 			name: 'Auth',
@@ -1495,7 +1492,6 @@ export class ZimbraBatchClient {
 					by: 'name',
 					_content: username
 				},
-				...(ignoreSameSite && { ignoreSameSite }),
 				...(password && { password }),
 				...(recoveryCode && {
 					recoveryCode: {

--- a/src/batch-client/types.ts
+++ b/src/batch-client/types.ts
@@ -245,7 +245,6 @@ export interface ModifyProfileImageOptions {
 export interface LoginOptions {
 	csrfTokenSecured: boolean;
 	deviceTrusted?: boolean;
-	ignoreSameSite?: boolean;
 	password: string;
 	persistAuthTokenCookie?: boolean;
 	recoveryCode?: string;

--- a/src/schema/generated-schema-types.ts
+++ b/src/schema/generated-schema-types.ts
@@ -1534,7 +1534,6 @@ export type EnableTwoFactorAuthInput = {
   authToken?: InputMaybe<Scalars['String']['input']>;
   csrfTokenSecured: Scalars['Boolean']['input'];
   email?: InputMaybe<Scalars['String']['input']>;
-  ignoreSameSite?: InputMaybe<Scalars['Boolean']['input']>;
   method: Scalars['String']['input'];
   name: Scalars['String']['input'];
   password?: InputMaybe<Scalars['String']['input']>;
@@ -3017,7 +3016,6 @@ export type MutationItemActionArgs = {
 export type MutationLoginArgs = {
   csrfTokenSecured: Scalars['Boolean']['input'];
   deviceTrusted?: InputMaybe<Scalars['Boolean']['input']>;
-  ignoreSameSite?: InputMaybe<Scalars['Boolean']['input']>;
   password?: InputMaybe<Scalars['String']['input']>;
   persistAuthTokenCookie?: InputMaybe<Scalars['Boolean']['input']>;
   recoveryCode?: InputMaybe<Scalars['String']['input']>;

--- a/src/schema/schema.graphql
+++ b/src/schema/schema.graphql
@@ -3089,7 +3089,6 @@ input EnableTwoFactorAuthInput {
 	twoFactorCode: String
 	authToken: String
 	csrfTokenSecured: Boolean!
-	ignoreSameSite: Boolean
 }
 
 input SendTwoFactorAuthCodeInput {
@@ -3771,7 +3770,6 @@ type Mutation {
 		twoFactorCode: String
 		deviceTrusted: Boolean
 		csrfTokenSecured: Boolean!
-		ignoreSameSite: Boolean
 	): AuthResponse
 	enableTwoFactorAuth(
 		options: EnableTwoFactorAuthInput!


### PR DESCRIPTION
Previously, we implemented the ignoreSameSite option in authRequest to prevent authentication failures caused by the addition of the SameSite cookie flag in the backend, as outlined in https://synacor.atlassian.net/browse/ZBUG-2397

With the recent updates in Electron, we are now explicitly setting SameSite=None for cookies in our application. As a result, the ignoreSameSite option is no longer necessary and can be safely removed.