### PR TITLE
ZBUG-4013: fixed issue of shared folders not visible to external accounts

### DIFF
--- a/src/schema/generated-schema-types.ts
+++ b/src/schema/generated-schema-types.ts
@@ -145,6 +145,7 @@ export type AccountInfoAttrs = {
   zimbraIdentityMaxNumEntries?: Maybe<Scalars['Int']['output']>;
   zimbraIsAdminAccount?: Maybe<Scalars['Boolean']['output']>;
   zimbraIsDelegatedAdminAccount?: Maybe<Scalars['Boolean']['output']>;
+  zimbraIsExternalVirtualAccount?: Maybe<Scalars['Boolean']['output']>;
   zimbraMailAlias?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
   zimbraMailAttachmentMaxSize?: Maybe<Scalars['Float']['output']>;
   zimbraMailBlacklistMaxNumEntries?: Maybe<Scalars['Int']['output']>;

--- a/src/schema/schema.graphql
+++ b/src/schema/schema.graphql
@@ -1460,6 +1460,7 @@ type AccountInfoAttrs {
 	zimbraDumpsterEnabled: Boolean
 	zimbraIsAdminAccount: Boolean
 	zimbraIsDelegatedAdminAccount: Boolean
+	zimbraIsExternalVirtualAccount: Boolean
 	zimbraFeatureMailEnabled: Boolean
 	zimbraFeatureCalendarEnabled: Boolean
 	zimbraFeatureBriefcasesEnabled: Boolean


### PR DESCRIPTION
`zimbraIsExternalVirtualAccount` will be used to determine whether user is external user or not and show the external user the shared folders.