### PR TITLE
PREAPPS-8505: Tag icons not updated in mail list item when multiple tags assign/unassign to an item

### DIFF
--- a/src/schema/generated-schema-types.ts
+++ b/src/schema/generated-schema-types.ts
@@ -2759,6 +2759,7 @@ export type MutationActionArgs = {
   folderId?: InputMaybe<Scalars['ID']['input']>;
   id?: InputMaybe<Scalars['ID']['input']>;
   ids?: InputMaybe<Array<Scalars['ID']['input']>>;
+  isBatchOperation?: InputMaybe<Scalars['Boolean']['input']>;
   isLocal?: InputMaybe<Scalars['Boolean']['input']>;
   name?: InputMaybe<Scalars['String']['input']>;
   op: Scalars['String']['input'];

--- a/src/schema/schema.graphql
+++ b/src/schema/schema.graphql
@@ -3694,6 +3694,7 @@ type Mutation {
 		tagNames: String
 		name: String
 		isLocal: Boolean
+		isBatchOperation: Boolean
 		recursive: Boolean
 		destFolderLocal: Boolean
 	): Boolean


### PR DESCRIPTION
Update the schema to support batch operations of actionRequest for message and conversation