### PR TITLE
ZBUG-5434: Attachment Not Displaying in Modern UI

### DIFF
--- a/src/utils/normalize-mime-parts.ts
+++ b/src/utils/normalize-mime-parts.ts
@@ -87,7 +87,7 @@ export function normalizeMimeParts(
 			if (forcedContentDisposition === 'attachments') {
 				attachment.contentDisposition = 'attachment';
 			} else if (forcedContentDisposition === 'inlineAttachments') {
-				attachment.contentDisposition === 'inline';
+				attachment.contentDisposition = 'inline';
 			}
 		}
 
@@ -185,6 +185,12 @@ export function normalizeMimeParts(
 			// remaining non-body, non-enclosure parts are attachments:
 			if (!isBody && type.split('/')[0] !== 'multipart') {
 				let mode = isInline ? 'inlineAttachments' : 'attachments';
+
+				// If inline but NOT an image, treat as regular attachment
+				if (isInline && !type.startsWith('image/')) {
+					mode = 'attachments';
+					part.contentDisposition = 'attachment';
+				}
 
 				!ignoreContentTypeToShowAsAttachment.includes(part.contentType) &&
 					(acc[mode] || (acc[mode] = [])).push(processAttachment(part, mode));


### PR DESCRIPTION
### Implementation:

- Convert inline attachments that are not image types to regular attachments