### PR TITLE
PREAPPS-9181: Use separate attribute to save group by date preference in modern UI

### DIFF
--- a/src/schema/generated-schema-types.ts
+++ b/src/schema/generated-schema-types.ts
@@ -2424,7 +2424,7 @@ export type MailboxMetadataAttrs = {
   zimbraPrefFolderTreeSash?: Maybe<Scalars['Int']['output']>;
   zimbraPrefFoldersExpanded?: Maybe<Scalars['String']['output']>;
   zimbraPrefGenerateLinkPreviews?: Maybe<Scalars['Boolean']['output']>;
-  zimbraPrefGroupByList?: Maybe<Scalars['String']['output']>;
+  zimbraPrefGroupByListModern?: Maybe<Scalars['String']['output']>;
   zimbraPrefHideMuteConvModal?: Maybe<Scalars['Boolean']['output']>;
   zimbraPrefMessageListDensity?: Maybe<Scalars['String']['output']>;
   zimbraPrefMultitasking?: Maybe<Scalars['String']['output']>;
@@ -2458,7 +2458,7 @@ export type MailboxMetadataSectionAttrsInput = {
   zimbraPrefFolderTreeSash?: InputMaybe<Scalars['Int']['input']>;
   zimbraPrefFoldersExpanded?: InputMaybe<Scalars['String']['input']>;
   zimbraPrefGenerateLinkPreviews?: InputMaybe<Scalars['Boolean']['input']>;
-  zimbraPrefGroupByList?: InputMaybe<Scalars['String']['input']>;
+  zimbraPrefGroupByListModern?: InputMaybe<Scalars['String']['input']>;
   zimbraPrefHideMuteConvModal?: InputMaybe<Scalars['Boolean']['input']>;
   zimbraPrefMessageListDensity?: InputMaybe<Scalars['String']['input']>;
   zimbraPrefMultitasking?: InputMaybe<Scalars['String']['input']>;

--- a/src/schema/schema.graphql
+++ b/src/schema/schema.graphql
@@ -2141,7 +2141,7 @@ type MailboxMetadataAttrs {
 	zimbraPrefFoldersExpanded: String
 	zimbraPrefFolderTreeSash: Int
 	zimbraPrefGenerateLinkPreviews: Boolean
-	zimbraPrefGroupByList: String
+	zimbraPrefGroupByListModern: String
 	zimbraPrefMessageListDensity: String
 	zimbraPrefMultitasking: String
 	zimbraPrefReadingPaneSashHorizontal: Int
@@ -2178,7 +2178,7 @@ input MailboxMetadataSectionAttrsInput {
 	zimbraPrefFoldersExpanded: String
 	zimbraPrefFolderTreeSash: Int
 	zimbraPrefGenerateLinkPreviews: Boolean
-	zimbraPrefGroupByList: String
+	zimbraPrefGroupByListModern: String
 	zimbraPrefMessageListDensity: String
 	zimbraPrefMultitasking: String
 	zimbraPrefReadingPaneSashHorizontal: Int


### PR DESCRIPTION
Use separate attribute to save group by date preference in modern UI to avoid any conflict with classic UI and also keep it enabled by default.