### PR TITLE
PREAPPS-9316 Conversation size shows 0 bytes on viewing conversation

### DIFF
--- a/src/apollo/zimbra-in-memory-cache.ts
+++ b/src/apollo/zimbra-in-memory-cache.ts
@@ -113,6 +113,14 @@ const typePolicies = {
 				// but as our app is already handling at caller level
 				// we are just overwriting cache data here
 				merge: false
+			},
+			sortField: {
+				merge(existing: string, incoming: string) {
+					if (incoming !== null && incoming !== undefined) {
+						return incoming;
+					}
+					return existing;
+				}
 			}
 		}
 	},


### PR DESCRIPTION
- Prevent conversation size update with null and undefined in the cache.