### PR TITLE
PREAPPS-9289: Fixed accountInfo cache overwrite issue

### DIFF
--- a/src/apollo/zimbra-in-memory-cache.ts
+++ b/src/apollo/zimbra-in-memory-cache.ts
@@ -93,6 +93,28 @@ const typePolicies = {
 			}
 		}
 	},
+	AccountInfo: {
+		fields: {
+			attrs: {
+				merge: true
+			},
+			habRoots: {
+				merge: true
+			},
+			license: {
+				merge: true
+			},
+			zimlets: {
+				merge: true
+			},
+			props: {
+				merge: true
+			},
+			cos: {
+				merge: true
+			}
+		}
+	},
 	Contact: {
 		fields: {
 			attributes: {


### PR DESCRIPTION
**Issue -**
In the briefcase vertical uploading a file incorrectly overwrites the `AccountInfo` cache with `zimbraMailQuota` data.

**Root Cause -**
The `used` value fetched within the `AccountInfo` type was unintentionally overwriting nested cache objects (such as attrs and zimlets). Because Apollo cannot track the identity of those nested objects independently, it clears the old parent object cache and writes the new incoming payload over it.

This was introduced in PR - [https://github.com/Zimbra/zm-x-web/pull/6038](https://github.com/Zimbra/zm-x-web/pull/6038/changes#diff-77171395e2614813efe1d5044880079e30f55505274797894763368830092719R8-R17)

**Fixes -**
Updated typolicies for type `AccountInfo` with `merge: true` for nested objects such as attrs, zimlets etc since Apollo merge does not perform deep merge on nestes objects
