### PR TITLE
PREAPPS-9328: Fetch multiple contact cert data at once

### DIFF
--- a/src/batch-client/index.ts
+++ b/src/batch-client/index.ts
@@ -1433,16 +1433,19 @@ export class ZimbraBatchClient {
 			namespace: Namespace.Account
 		}).then(certificate => normalize(SmimeCertInfoResponse)(certificate || {}));
 
-	public getSMimePublicCerts = (options: GetSMimePublicCertsOptions) =>
+	public getSMimePublicCerts = ({ contactAddr, store }: GetSMimePublicCertsOptions) =>
 		this.jsonRequest({
 			name: 'GetSMIMEPublicCerts',
 			body: {
 				store: {
-					_content: options.store
+					_content: store
 				},
-				email: {
-					_content: options.contactAddr
-				}
+				email:
+					typeof contactAddr === 'string'
+						? {
+								_content: contactAddr
+							}
+						: contactAddr.map(add => ({ _content: add }))
 			},
 			namespace: Namespace.Account
 		});

--- a/src/batch-client/types.ts
+++ b/src/batch-client/types.ts
@@ -308,7 +308,7 @@ export interface CreateSearchFolderOptions {
 }
 
 export interface GetSMimePublicCertsOptions {
-	contactAddr: string;
+	contactAddr: string | Array<string>;
 	store: string;
 }
 

--- a/src/schema/generated-schema-types.ts
+++ b/src/schema/generated-schema-types.ts
@@ -3907,7 +3907,7 @@ export type QueryGetSMimeCertInfoArgs = {
 
 
 export type QueryGetSMimePublicCertsArgs = {
-  contactAddr: Scalars['String']['input'];
+  contactAddr: Array<InputMaybe<Scalars['String']['input']>>;
   store: Scalars['String']['input'];
 };
 

--- a/src/schema/schema.graphql
+++ b/src/schema/schema.graphql
@@ -3648,7 +3648,7 @@ type Query {
 	getMessagesMetadata(ids: [ID!]!, isLocal: Boolean): [MessageInfo]
 	getRights(input: GetRightsInput!): RightsResponse
 	getSMimePublicCerts(
-		contactAddr: String!
+		contactAddr: [String]!
 		store: String!
 	): SMimePublicCertsResponse
 	getSMimeCertInfo(certId: String): SmimeCertInfoResponse


### PR DESCRIPTION
`getSMimePublicCerts` api supports fetching certificates of multiple contacts at once. This changes enables that behaviour.

Note: Changes have been reviewed under child branch PR - https://github.com/Zimbra/zm-api-js-client/pull/827